### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ "main" ]
 
+permissions:
+  contents: read
+
 env:
   CARGO_TERM_COLOR: always
 


### PR DESCRIPTION
Potential fix for [https://github.com/eng-c/ec/security/code-scanning/1](https://github.com/eng-c/ec/security/code-scanning/1)

In general, the fix is to explicitly declare a `permissions` block in the workflow (either at the top-level or per job) to control the `GITHUB_TOKEN` scopes, instead of relying on inherited repository/organization defaults. For this workflow, the job only checks out code and runs local commands, so setting `contents: read` is a safe minimal starting point.

The best fix without changing existing functionality is to add a `permissions` block at the workflow root (so it applies to all jobs) right after the `on:` trigger block. This aligns with CodeQL’s recommendation and keeps the YAML structure clear. Concretely, in `.github/workflows/rust.yml`, between the existing `on:` section (lines 3–7) and the `env:` section (line 9), add:
```yaml
permissions:
  contents: read
```
No additional imports or external tools are required; this is purely a YAML configuration change for GitHub Actions.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
