### PR TITLE
Update LANGUAGE.md and README.md for 0.1.10 -> 0.1.15 drift

### DIFF
--- a/LANGUAGE.md
+++ b/LANGUAGE.md
@@ -1,6 +1,6 @@
 # Vox Language Specification
 
-**Version 0.1.10**
+**Version 0.1.15**
 
 This document defines the syntax and semantics of Vox (sentence based code).
 
@@ -16,11 +16,17 @@ This document defines the syntax and semantics of Vox (sentence based code).
 6. [Control Flow](#control-flow)
 7. [Lists and Collections](#lists-and-collections)
 8. [Input/Output](#inputoutput)
-9. [Operators](#operators)
-10. [Keywords](#keywords)
-11. [Libraries and Imports](#libraries-and-imports)
-12. [Compiler Usage](#compiler-usage)
-13. [Grammar Summary](#grammar-summary)
+9. [File I/O](#file-io)
+10. [Directories, Mounting, and Process Control](#directories-mounting-and-process-control)
+11. [Time and Timers](#time-and-timers)
+12. [Command-Line Arguments](#command-line-arguments)
+13. [Environment Variables](#environment-variables)
+14. [Operators](#operators)
+15. [Keywords](#keywords)
+16. [Examples](#examples)
+17. [Libraries and Imports](#libraries-and-imports)
+18. [Compiler Usage](#compiler-usage)
+19. [Grammar Summary](#grammar-summary)
 
 ---
 
@@ -1364,11 +1370,24 @@ Close output.
 
 ### File Operations
 
-Check if a file exists:
+Check if a file (or any path) is available:
 
 ```
-If "data.txt" exists then,
+If "data.txt" is available then,
     print "File found.".
+```
+
+`is available` (compiles to `access(2)` with `F_OK`) is the correct, current
+form of this check. It works on any path expression - string literal, text
+variable, or buffer - and is not limited to plain files; see
+[Directories, Mounting, and Process Control](#directories-mounting-and-process-control)
+for how it is used to poll for a device node.
+
+Negate with `is not available`:
+
+```
+While the root_device is not available,
+    Sleep for 100 milliseconds.
 ```
 
 Delete a file:
@@ -1474,6 +1493,174 @@ If condition is true then,
 | Forgot to free memory | Memory leak | Auto-freed on exit |
 | Double free | Undefined behavior | Tracked - can't happen |
 | Use after free | Undefined behavior | Not possible by design |
+
+---
+
+## Directories, Mounting, and Process Control
+
+These constructs were added for writing early-userspace/init-style programs
+in Vox - see [examples/initramfs.vox](examples/initramfs.vox) for a complete,
+working early-userspace init sequence exercising all of them together.
+
+### Directories
+
+```
+Create a directory called "/proc".
+Remove the directory called "/proc".
+Delete the directory "/proc".
+Change directory to "/newroot".
+```
+
+**Rules:**
+- `Create a directory called "<path>".` - `mkdir(2)`, mode `0755`. The article
+  (`a`) is optional; `called` is required.
+- `Remove the directory called "<path>".` / `Delete the directory "<path>".` -
+  `rmdir(2)`. Both `Remove` and `Delete` work; `the` and `called` are optional.
+- `Change directory to "<path>".` - `chdir(2)`.
+- All three set the error flag on failure - use `On error` to catch it.
+
+### Mounting Filesystems
+
+```
+Mount "proc" at "/proc" with type "proc".
+Mount "tmpfs" at "/dev/shm" with type "tmpfs" with options "size=64m".
+On error print "mount failed", exit 1.
+
+Unmount "/dev/shm".
+Unmount "/dev/shm" lazily.
+On error print "unmount failed".
+```
+
+**Rules:**
+- `Mount "<source>" at "<target>" with type "<fstype>" [with options "<options>"].`
+  lowers directly to `mount(2)`. `source`/`target`/`fstype`/`options` accept
+  string literals, text variables, or buffers (including format-string-built
+  buffers).
+- Moving/binding an already-mounted filesystem uses `fstype "none"` with
+  `options "move"` or `options "bind"` - Vox recognizes this pattern and
+  translates it into the correct `MS_MOVE`/`MS_BIND` mount flags:
+  ```
+  Mount "/proc" at "/newroot/proc" with type "none" with options "move".
+  ```
+- `Unmount "<target>".` - `umount2(2)`. `umount` is accepted as an alias for
+  `Unmount`. Append `lazily` for `MNT_DETACH` (detaches immediately and
+  releases the mount once nothing is using it any longer, instead of failing
+  with "device busy") - needed when unmounting a filesystem your own running
+  program was loaded from.
+- Both set the error flag on failure.
+
+### Device Nodes
+
+```
+Create a device node called "/dev/null" with type "c" major 1 minor 3.
+Create a device node called "/dev/loop0" with type "b" major 7 minor 0.
+```
+
+`mknod(2)`. `type` is `"c"` (character device) or `"b"` (block device);
+`major`/`minor` are the standard Linux device-driver identification numbers
+(see `man 4 null`/the kernel's `Documentation/admin-guide/devices.txt` for
+the registry of standard values). Sets the error flag on failure.
+
+### Symbolic Links
+
+```
+Create symbolic link from "/proc/self/fd" to "/dev/fd".
+```
+
+`symlink(2)`: `Create symbolic link from "<target>" to "<linkpath>".` Sets
+the error flag on failure.
+
+### Switching the Root Filesystem
+
+```
+Pivot root to "/newroot" with old root "/newroot/oldroot".
+```
+
+`pivot_root(2)`. `put_old` (the second path) must be a directory that
+already exists *inside* `new_root` - create it after mounting the new root,
+not before. After a successful pivot, the previous root filesystem is
+accessible at `put_old`'s path relative to the new root (here, `/oldroot`),
+and should typically be released with `Unmount "..." lazily` once your
+program has `chdir`'d away from it. Sets the error flag on failure.
+
+### Executing Programs
+
+```
+Execute "/bin/sh".
+Execute "/bin/echo" with arguments ["hello", "world"].
+
+a list called "cmdargs" is ["hello", "world"].
+Execute "/bin/echo" with arguments cmdargs.
+
+On error print "execve failed", exit 1.
+```
+
+`execve(2)` - replaces the current process image entirely. Three forms:
+
+- **No arguments**: `Execute "<path>".` synthesizes `argv = [path, NULL]`
+  (argc 1).
+- **Literal argument list**: `Execute "<path>" with arguments [...].` - argv
+  is built at compile time.
+- **List variable**: `Execute "<path>" with arguments <list>.` - argv is
+  built at runtime from the list's current length and contents, sized and
+  bounds-checked from that single length read so the argv array cannot be
+  overrun regardless of the list's contents.
+
+The environment is inherited from the calling process in all three forms.
+`execve` only ever returns on failure (there is no "success" path to return
+to - the process image is gone), so `On error` after `Execute` is the normal
+and only way to detect that it didn't work.
+
+### Process Control: fork and reap
+
+```
+Set pid to fork the process.
+If pid is 0 then,
+    (this branch runs in the child)
+    Execute "/bin/some-program".
+If pid is greater than 0 then,
+    (this branch runs in the parent - pid holds the child's real PID)
+    Set reaped to reap any child process.
+```
+
+These are **expressions**, not statements - use them anywhere an expression
+is valid (typically the right-hand side of `Set`/`a number called ... is`).
+
+- `fork the process` (the trailing `the process` is optional; bare `fork`
+  also works) - `fork(2)`. Returns `0` in the child, the child's PID in the
+  parent, or a negative value on error. Sets the error flag on failure.
+- `reap any child process` - `wait4(2)` with `pid = -1`, waiting for any
+  child. Returns the reaped child's PID, or a negative value on error.
+- `reap process <pid-expr>` / `reap child <pid-expr>` - `wait4(2)` for a
+  specific PID.
+
+Both set the error flag on failure (e.g. `On error` after `reap process 999999`
+catches `ECHILD` when the PID is not actually your child).
+
+### System Control: Shutdown, Reboot, Halt
+
+```
+Shutdown.
+On error print "shutdown failed - are you root?".
+
+Reboot.
+Halt.
+```
+
+`reboot(2)`, requiring `CAP_SYS_BOOT` (root). Each statement calls `sync(2)`
+first to flush filesystem buffers, then issues the matching command:
+
+| Statement | Aliases | Command |
+|-----------|---------|---------|
+| `Shutdown` | `Poweroff` | `LINUX_REBOOT_CMD_POWER_OFF` |
+| `Reboot` | `Restart` | `LINUX_REBOOT_CMD_RESTART` |
+| `Halt` | - | `LINUX_REBOOT_CMD_HALT` |
+
+**On success, none of these return** - the machine powers off/restarts/halts.
+On failure (not root, or no `CAP_SYS_BOOT`), the error flag is set instead of
+crashing or exiting, so `On error` safely catches the failure and execution
+continues - an unprivileged or accidental invocation can never bring down
+the machine.
 
 ---
 
@@ -1969,6 +2156,12 @@ Set result to value bit-shift-right 8 bit-and 0xFF.
 | `Continue` | Skip to next iteration |
 | `Exit` | Terminate program with exit code |
 | `Append` | Add element to list |
+| `Create`, `Change`, `Remove`/`Delete` | Directories, device nodes, symlinks, chdir (see [Directories, Mounting, and Process Control](#directories-mounting-and-process-control)) |
+| `Mount`, `Unmount`/`Umount` | Mount/unmount filesystems |
+| `Pivot` | `pivot_root` - switch the root filesystem |
+| `Execute` | `execve` - replace the process image |
+| `Shutdown`/`Poweroff`, `Reboot`/`Restart`, `Halt` | `reboot(2)` - power off/restart/halt the machine |
+| `fork`, `reap` | Process control expressions - `fork(2)`/`wait4(2)` |
 
 ### Connectors
 

--- a/README.md
+++ b/README.md
@@ -94,6 +94,10 @@ This makes Vox well-suited for static utilities, constrained environments, and s
 * Compile-time memory and resource tracking
 * Modular library of core macros with dependency inclusion
 * Extremely small statically linked executables
+* Filesystem, mount, and process-control operations (directories, device
+  nodes, symlinks, mount/unmount, `pivot_root`, `execve`, `fork`/`reap`,
+  `shutdown`/`reboot`/`halt`) - enough to write a working early-userspace
+  init entirely in Vox; see [examples/initramfs.vox](examples/initramfs.vox)
 
 ---
 
@@ -224,7 +228,7 @@ Vox is under active development. Planned work includes:
    Planned targets include Win64, AArch64, ARM64, MIPS, and RISC-V.
 
 5. **Expanded System Interfaces**
-   Higher-level abstractions for multithreading, file descriptor polling, filesystem operations, and system control.
+   Filesystem operations (directories, device nodes, symlinks), mounting, `pivot_root`, `execve`, basic process control (`fork`/`reap`), and system control (`shutdown`/`reboot`/`halt`) are implemented. Remaining: higher-level abstractions for multithreading and file descriptor polling (epoll/poll).
 
 6. **Math and Numeric Optimization**
    Continued optimization of numeric code generation, with a goal of matching or exceeding C performance in benchmarks.


### PR DESCRIPTION
LANGUAGE.md hadn't been touched since it was written against 0.1.10; diffed everything since (commit 7d5895d, the last commit that actually edited it) to find the real scope of undocumented changes rather than going by version-bump commits, several of which bundled multiple releases together.

- Version header: 0.1.10 -> 0.1.15
- New section "Directories, Mounting, and Process Control": mkdir/ rmdir/chdir, mount/unmount (including the move/bind pseudo-mount pattern and lazy detach), mknod, symlink, pivot_root, all three Execute forms (no-args, literal list, list variable), and fork/reap/shutdown/reboot/halt. Every form verified against the actual parser grammar, not written from memory.
- Fixed a real, verified bug in the existing docs: "File Operations" documented `If "data.txt" exists then,`, which does not parse (confirmed: "Expected a statement, got Exists"). Replaced with the actual working form, `is available`.
- Rebuilt the Table of Contents, which was already missing several existing sections (File I/O, Time and Timers, Command-Line Arguments, Environment Variables, Examples) before any of this change - now matches every actual section header.
- Keywords table: added the new statement starters.

README.md:
- Features list: added the filesystem/mount/process-control surface, linking to examples/initramfs.vox as the working demonstration.
- Roadmap item 5 ("Expanded System Interfaces"): updated from all-future-work to reflect what's delivered (filesystem ops, mounting, pivot_root, execve, fork/reap, shutdown/reboot/halt) vs. what remains (multithreading, fd polling).