### PR TITLE
Fix two function-related type-tracking bugs found building a substrin…

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -59,7 +59,7 @@ checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
 name = "vox"
-version = "0.1.15"
+version = "0.1.16"
 dependencies = [
  "thiserror",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vox"
-version = "0.1.15"
+version = "0.1.16"
 edition = "2021"
 description = "A systems level compiler for Vox (sentence based code)"
 

--- a/LANGUAGE.md
+++ b/LANGUAGE.md
@@ -1,6 +1,6 @@
 # Vox Language Specification
 
-**Version 0.1.15**
+**Version 0.1.16**
 
 This document defines the syntax and semantics of Vox (sentence based code).
 
@@ -331,6 +331,36 @@ To "check divisibility" of a number called "divisor" and a number called "divide
 - Variables declared at top level are global and can be used inside functions.
 - Variables declared inside a function are local to that function and are not available at top level.
 - Referencing an unknown variable inside a function is a compile-time error.
+
+### Parameter and Local Types (v0.1.16)
+
+Parameters may use any variable type, including `buffer`, `list`, and
+`file` - and a typed parameter supports the same properties and
+operations as a top-level variable of that type:
+
+```
+To "contains token" of a buffer called "hay" and a text called "devname".
+  a buffer called "needle" is " {devname}\n".
+  a number called "H" is hay's size.
+  a number called "b" is byte 1 of hay.
+  ...
+```
+
+Key points:
+
+- Buffer parameters support `'s size`/`'s empty`/`'s full` and byte
+  access; list parameters support `'s length`/element access; file
+  parameters support file properties.
+- Buffers declared **inside** a function body work with every
+  initializer form, including format strings (`is " {devname}\n"`).
+- A function call's declared return type is tracked through
+  assignment: reassigning an existing variable from a call
+  (`the label is "classify" of n.`) preserves the correct type.
+
+(All three of the above were fixed in v0.1.16 - in earlier versions,
+buffer-typed parameters and function-local buffer declarations with
+initializers were rejected by the analyzer, and reassignment from a
+function call silently corrupted the variable's tracked type.)
 
 ### Function Calls
 

--- a/src/analyzer/mod.rs
+++ b/src/analyzer/mod.rs
@@ -1424,9 +1424,23 @@ impl Analyzer {
                 self.in_function_scope = true;
                 self.block_depth = 0;
 
-                // Add function parameters to function scope.
-                for (param_name, _) in params {
+                // Add function parameters to function scope. Buffer/list/file
+                // typed parameters must also be recorded in their
+                // type-specific sets, exactly like a VarDecl/BufferDecl at
+                // top level would - otherwise `param's size`/`empty`/`full`
+                // (and other buffer/list/file-only properties) incorrectly
+                // report "requires a buffer, list, or file variable" for
+                // the parameter itself. This previously only appeared to
+                // work when a same-named top-level variable of the correct
+                // type happened to already exist elsewhere in the program.
+                for (param_name, param_type) in params {
                     self.variables.insert(param_name.clone());
+                    match param_type {
+                        Type::Buffer => { self.buffer_variables.insert(param_name.clone()); }
+                        Type::List(_) => { self.list_variables.insert(param_name.clone()); }
+                        Type::File => { self.file_variables.insert(param_name.clone()); }
+                        _ => {}
+                    }
                 }
                 for s in body {
                     self.analyze_statement(s);

--- a/src/analyzer/mod.rs
+++ b/src/analyzer/mod.rs
@@ -1257,6 +1257,22 @@ impl Analyzer {
             
             Statement::VarDecl { name, var_type, value } => {
                 self.declare_variable_in_current_scope(name);
+                // Register the declared type in the type-specific sets,
+                // mirroring the top-level pre-pass. That pre-pass only
+                // walks program.statements and never descends into
+                // function bodies, so without this a `a buffer called "x"
+                // is "..."` INSIDE a function was never recorded as a
+                // buffer and property/byte access on it was rejected.
+                // (`a buffer called "x" is N bytes in size.` parses as
+                // BufferDecl - a different statement whose arm already
+                // registers - which is why only the initializer form
+                // failed.)
+                if let Some(Type::Buffer) = var_type {
+                    self.buffer_variables.insert(name.clone());
+                }
+                if let Some(Type::List(_)) = var_type {
+                    self.list_variables.insert(name.clone());
+                }
                 self.maybe_activate_true_guard(name, var_type, value);
                 if let Some(v) = value {
                     self.analyze_expr(v);

--- a/src/codegen/mod.rs
+++ b/src/codegen/mod.rs
@@ -32,6 +32,11 @@ pub struct CodeGenerator {
     // analyzer computes from string literals/format strings and may miss
     // a pure variable-vs-variable comparison with no literal operand.
     uses_strings: bool,
+    // Declared return type of each user function, keyed by function name.
+    // Populated by collect_function_signatures() before codegen so
+    // infer_expr_type() can report a FunctionCall's real type instead of
+    // silently defaulting to Integer (see collect_function_signatures).
+    function_return_types: std::collections::HashMap<String, VarType>,
     loop_stack: Vec<(String, String)>, // (continue_label, break_label)
     flag_schemas: Vec<FlagSchemaRuntime>,
     parsed_args_active: bool,
@@ -106,6 +111,7 @@ impl CodeGenerator {
             uses_funcs: false,
             uses_lists: false,
             uses_strings: false,
+            function_return_types: std::collections::HashMap::new(),
             loop_stack: Vec::new(),
             flag_schemas: Vec::new(),
             parsed_args_active: false,
@@ -409,6 +415,32 @@ impl CodeGenerator {
         }
     }
 
+    // Record each function's declared return type so infer_expr_type() can
+    // resolve Expr::FunctionCall correctly instead of falling through to
+    // its generic "Integer for anything unrecognized" default. Without
+    // this, reassigning an EXISTING variable from a function call (`the x
+    // is "some func" of y.`) silently corrupted the variable's tracked
+    // type to Integer - a fresh `a text called "x" is ...` declaration
+    // happened to read the correct type from a different code path and
+    // was unaffected, which is what made this easy to miss.
+    fn collect_function_signatures(&mut self, program: &Program) {
+        self.function_return_types.clear();
+        for stmt in &program.statements {
+            if let Statement::FunctionDef { name, return_type, .. } = stmt {
+                let vt = match return_type {
+                    Type::Integer => VarType::Integer,
+                    Type::Float => VarType::Float,
+                    Type::String => VarType::String,
+                    Type::Boolean => VarType::Boolean,
+                    Type::Buffer => VarType::Buffer,
+                    Type::List(_) => VarType::List,
+                    _ => VarType::Unknown,
+                };
+                self.function_return_types.insert(name.clone(), vt);
+            }
+        }
+    }
+
     fn collect_flag_schemas(&mut self, program: &Program) {
         self.flag_schemas.clear();
         for stmt in &program.statements {
@@ -661,6 +693,7 @@ impl CodeGenerator {
     pub fn generate(&mut self, program: &Program) -> String {
         self.collect_global_constants(program);
         self.collect_flag_schemas(program);
+        self.collect_function_signatures(program);
 
         self.global_var_labels.clear();
         self.global_var_counter = 0;
@@ -4259,6 +4292,7 @@ impl CodeGenerator {
             | Expr::EnvironmentVariableEmpty => Some(VarType::Integer),
             Expr::ArgumentAll | Expr::ArgumentRaw => Some(VarType::List),
             Expr::Identifier(name) => self.variable_types.get(name).cloned(),
+            Expr::FunctionCall { name, .. } => self.function_return_types.get(name).cloned(),
             Expr::PropertyAccess { object, property } => {
                 // For First/Last on lists, return the list's element type
                 match property {

--- a/tests/104_function_call_reassign_type.expected
+++ b/tests/104_function_call_reassign_type.expected
@@ -1,0 +1,3 @@
+before: start
+after reassign (1): one
+after reassign (2): two

--- a/tests/104_function_call_reassign_type.vox
+++ b/tests/104_function_call_reassign_type.vox
@@ -1,0 +1,22 @@
+(Regression test: reassigning an EXISTING variable from a function call
+ must preserve the variable's real type. infer_expr_type() had no case
+ for Expr::FunctionCall and fell through to a generic "default to
+ Integer" fallback; Assignment codegen trusted that inferred type and
+ overwrote the variable's correct type with Integer. A FRESH `a text
+ called "x" is "func" of y.` declaration used a different code path and
+ was unaffected, which is what made this easy to miss - only
+ REASSIGNMENT of an already-declared variable was broken.)
+
+To "classify" of a number called "n".
+  If n is 1 then,
+      Return a text, "one".
+  If n is 2 then,
+      Return a text, "two".
+  Return a text, "other".
+
+a text called "label" is "start".
+Print "before: {label}".
+the label is "classify" of 1.
+Print "after reassign (1): {label}".
+the label is "classify" of 2.
+Print "after reassign (2): {label}".

--- a/tests/105_function_buffer_param_properties.expected
+++ b/tests/105_function_buffer_param_properties.expected
@@ -1,0 +1,3 @@
+func one: size 5
+func two: size 5
+sizes: 5 5

--- a/tests/105_function_buffer_param_properties.vox
+++ b/tests/105_function_buffer_param_properties.vox
@@ -1,0 +1,23 @@
+(Regression test: a buffer-typed function PARAMETER must support
+ 'size'/'empty'/'full' the same as any top-level buffer variable. The
+ analyzer registered function parameters into the generic "known
+ variable" set but never into the type-specific buffer_variables/
+ list_variables/file_variables sets, so a parameter's own type was
+ invisible to the "is this a buffer?" check - this previously appeared
+ to work only when a same-named top-level variable of the correct type
+ happened to already exist elsewhere in the program (which masked the
+ bug rather than avoiding it). Two functions sharing a parameter name
+ makes sure the fix isn't accidentally scoped to a single function.)
+
+To "describe" of a buffer called "hay".
+  Print "func one: size {hay's size}".
+  Return a number, hay's size.
+
+To "describe again" of a buffer called "hay".
+  Print "func two: size {hay's size}".
+  Return a number, hay's size.
+
+a buffer called "data" is "hello".
+a number called "s1" is "describe" of data.
+a number called "s2" is "describe again" of data.
+Print "sizes: {s1} {s2}".

--- a/tests/106_function_local_buffer_decl.expected
+++ b/tests/106_function_local_buffer_decl.expected
@@ -1,0 +1,3 @@
+padded size: 6
+first byte: 32 (expect 32 = space)
+returned: 6

--- a/tests/106_function_local_buffer_decl.vox
+++ b/tests/106_function_local_buffer_decl.vox
@@ -1,0 +1,20 @@
+(Regression test: a buffer declared with an initializer INSIDE a
+ function body must be usable as a buffer. The analyzer's type pre-pass
+ only walks top-level statements and never descends into function
+ bodies, and the in-body VarDecl arm registered nothing - so
+ `a buffer called "x" is "...".` inside a function was never recorded
+ as a buffer, and property or byte access on it was rejected with
+ "requires a buffer, list, or file variable". The sized form
+ `a buffer called "x" is N bytes in size.` parses as a different
+ statement (BufferDecl) whose arm already registered, which is why only
+ the initializer form failed.)
+
+To "measure" of a text called "word".
+  a buffer called "padded" is " {word}\n".
+  a number called "first byte" is byte 1 of padded.
+  Print "padded size: {padded's size}".
+  Print "first byte: {first byte} (expect 32 = space)".
+  Return a number, padded's size.
+
+a number called "n" is "measure" of "sda2".
+Print "returned: {n}".


### PR DESCRIPTION
…g matcher

Both surfaced while building a reusable "does /proc/partitions contain this device name" helper for initramfs.vox - a genuinely common pattern (reassign a loop variable from a function call; pass a buffer to a helper function) that had never been exercised together before.

1. Reassigning an EXISTING variable from a function call corrupted its type. infer_expr_type() had no case for Expr::FunctionCall, so it fell through to the generic "default to Integer" fallback. Assignment codegen trusted that inferred type and overwrote the variable's real type - so `the label is "classify" of 1.` silently turned a text variable into one tracked as Integer, and subsequent printing showed a raw pointer as a garbage decimal number instead of dereferencing it as a string. A FRESH `a text called "x" is "classify" of 1.` declaration took a different code path and was unaffected, which is what made this easy to miss.

   Fixed properly rather than special-cased: added collect_function_signatures(), a pre-pass (alongside the existing collect_global_constants/collect_flag_schemas) that records each function's declared return type - already parsed and stored on FunctionDef, but never read by codegen - into a new function_return_types map. infer_expr_type() now resolves Expr::FunctionCall from that map instead of guessing.

2. A buffer/list/file-typed function PARAMETER did not support 'size'/'empty'/'full' (or other type-specific properties) - the analyzer registered parameters into the generic "known variable" set but never into the type-specific buffer_variables/ list_variables/file_variables sets that back the "is this actually a buffer?" check. This previously appeared to work whenever a same-named top-level variable of the correct type happened to already exist elsewhere in the program (coincidentally satisfying the check), which is exactly what masked it during initial development of a single-function test.

   Fixed by reading the parameter's actual declared type (previously discarded with `for (param_name, _) in params`) and inserting into the matching set, mirroring what VarDecl/BufferDecl already do at top level.

Tests: 104 (reassignment preserves type across two different return values), 105 (buffer parameter properties work, with two functions sharing a parameter name so the fix isn't accidentally scoped to one function). Suite: 95 passed, 0 failed.