### PR TITLE
v0.1.17: fix format strings in expression context, add sh.vox shell e…

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -59,7 +59,7 @@ checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
 name = "vox"
-version = "0.1.16"
+version = "0.1.17"
 dependencies = [
  "thiserror",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vox"
-version = "0.1.16"
+version = "0.1.17"
 edition = "2021"
 description = "A systems level compiler for Vox (sentence based code)"
 

--- a/LANGUAGE.md
+++ b/LANGUAGE.md
@@ -1,6 +1,6 @@
 # Vox Language Specification
 
-**Version 0.1.16**
+**Version 0.1.17**
 
 This document defines the syntax and semantics of Vox (sentence based code).
 
@@ -992,6 +992,31 @@ Print "Sum: {x add y}".
 Print "Product: {x multiply y}".
 Print "Arguments: {arguments's count}".
 ```
+
+#### Format Strings as Values (v0.1.17)
+
+Format strings are expressions, not just print arguments. Used as a
+value, a format string materializes into a fresh NUL-terminated string,
+so it works as a text initializer or assignment and survives being
+carried through lists (e.g. into an `Execute` argument list):
+
+```
+a buffer called "word" is 64 bytes in size.
+copy "hello" to word.
+
+a text called "tok" is "{word}".        (text from buffer contents)
+a text called "path" is "/bin/{tok}".   (text from another text)
+
+a list called "cmdargs" is [].
+append tok to cmdargs.
+Execute "/bin/echo" with arguments cmdargs.
+```
+
+Each evaluation allocates a new string; the source buffer can be
+cleared and reused without affecting texts already created from it.
+
+(Before v0.1.17, a format string outside `Print` compiled to a NULL
+pointer: it printed as empty and corrupted `execve` argv arrays.)
 
 #### Escape Sequences
 

--- a/examples/sh.vox
+++ b/examples/sh.vox
@@ -1,0 +1,76 @@
+(vsh - a minimal interactive shell)
+(Reads a command line, splits it into whitespace-separated tokens,
+ forks, and executes the command with its arguments. Commands are
+ tried as given, then under /bin and /usr/bin. Type "exit" to quit.
+
+ Tokens are collected byte-by-byte into a scratch buffer, then turned
+ into an argv-ready text with a format-string initializer - "{word}"
+ materializes the buffer's bytes as a fresh NUL-terminated string, so
+ every token owns its own memory and the scratch buffer can be reused.)
+
+A text called "Program Version" is "0.1.0".
+
+Open a file at 0 for reading called stdin.
+
+Create a buffer called line.
+a buffer called "word" is 256 bytes in size.
+
+While true,
+    print "vsh $ " without newline,
+    clear line,
+    read line from stdin into line,
+    if line is empty then, exit 0.
+    (A trailing separator guarantees the last token is flushed even if
+     the line arrived without a newline)
+    append " " to line,
+
+    a list called "argv" is [],
+    a text called "cmd" is "",
+    a text called "tok" is "",
+    a number called "have_cmd" is 0,
+    a number called "n" is line's size,
+    a number called "i" is 1,
+    a number called "b" is 0,
+    a number called "sep" is 0,
+    a number called "flush" is 0,
+    clear word,
+
+    (Scan the line. Non-separator bytes accumulate into word; hitting a
+     separator with a non-empty word finishes one token. The first token
+     is the command, the rest become its arguments.)
+    While i is less than or equal to n,
+        set b to byte i of line,
+        set sep to 0,
+        if b is 32 then, set sep to 1.
+        if b is 10 then, set sep to 1.
+        if b is 9 then, set sep to 1.
+        if sep is 0 then, set byte {word's size add 1} of word to b.
+        set flush to 0,
+        if sep is 1 and word's size is greater than 0 then, set flush to 1.
+        if flush is 1 then, a text called "tok" is "{word}".
+        (Order matters: append while have_cmd is already 1, THEN claim
+         the first token as the command - reversing these would also
+         append the command itself to its argument list)
+        if flush is 1 and have_cmd is 1 then, append tok to argv.
+        if flush is 1 and have_cmd is 0 then, set cmd to tok, set have_cmd to 1.
+        if flush is 1 then, clear word.
+        increment i.
+
+    a number called "pid" is 0,
+    if cmd is "exit" then, exit 0.
+    if have_cmd is 1 then, set pid to fork the process.
+
+    (Child: execve only returns on failure, so falling through to the
+     next Execute IS the search order: as given, /bin, /usr/bin)
+    if pid is 0 and have_cmd is 1 then,
+        Execute cmd with arguments argv,
+        a text called "binpath" is "/bin/{cmd}",
+        Execute binpath with arguments argv,
+        a text called "usrpath" is "/usr/bin/{cmd}",
+        Execute usrpath with arguments argv,
+        print "vsh: {cmd}: command not found",
+        exit 127.
+
+    (Parent: wait for the child so the prompt returns in order)
+    if pid is greater than 0 then, set reaped to reap process pid.
+    set flush to 0.

--- a/src/codegen/mod.rs
+++ b/src/codegen/mod.rs
@@ -4115,11 +4115,22 @@ impl CodeGenerator {
                 self.emit(&format!("{}:", done_label));
             }
             
-            // Format string - result is left in rax as a pointer (not used here, handled in generate_print)
-            Expr::FormatString { .. } => {
-                // Format strings are handled specially in generate_print
-                // For expression context, just return 0
-                self.emit_indent("xor rax, rax");
+            // Format string in expression context (e.g. a text initializer
+            // or a function argument): materialize it into a fresh dynamic
+            // buffer and yield a pointer to the data area - a NUL-terminated
+            // C string usable anywhere a text is. Previously this returned 0,
+            // so `a text called "t" is "{buf}"` silently produced a NULL
+            // text that printed as empty and crashed execve argv arrays.
+            Expr::FormatString { parts } => {
+                self.uses_buffers = true;
+                self.stack_offset += 8;
+                let tmp = self.stack_offset;
+                self.emit_indent("mov rdi, 1024  ; default buffer size");
+                self.emit_indent("call _alloc_buffer");
+                self.emit_indent(&format!("mov [rbp-{}], rax", tmp));
+                self.emit_format_parts_into_buffer_slot(tmp, parts, false);
+                self.emit_indent(&format!("mov rax, [rbp-{}]", tmp));
+                self.emit_indent("add rax, 24  ; buffer data area (header is 24 bytes)");
             }
         }
     }

--- a/tests/107_text_from_format_string.expected
+++ b/tests/107_text_from_format_string.expected
@@ -1,0 +1,3 @@
+text: hello-42
+hello-42 second
+done

--- a/tests/107_text_from_format_string.vox
+++ b/tests/107_text_from_format_string.vox
@@ -1,0 +1,26 @@
+(Regression test: a format string in EXPRESSION context - e.g. a text
+ initializer - must materialize its contents into memory and yield a
+ usable string pointer. Previously Expr::FormatString outside Print
+ emitted `xor rax, rax`, so `a text called "t" is "{buf}"` silently
+ produced a NULL text: it printed as empty, compared as empty, and
+ injected a NULL into execve argv arrays built from lists.)
+
+a buffer called "word" is 64 bytes in size.
+copy "hello" to word.
+a number called "n" is 42.
+
+a text called "t" is "{word}-{n}".
+Print "text: {t}".
+
+(The materialized text must survive being carried through a list into
+ an execve argv array - the original failure mode was a NULL argv[1])
+a list called "echoargs" is [].
+append t to echoargs.
+append "second" to echoargs.
+
+Set pid to fork the process.
+If pid is 0 then,
+    Execute "/bin/echo" with arguments echoargs.
+    On error print "exec failed", exit 1.
+Set reaped to reap process pid.
+Print "done".


### PR DESCRIPTION
…xample

A format string used as a value (text initializer, assignment, list element) compiled to xor rax, rax - a NULL pointer. It printed as empty and injected NULLs into execve argv arrays built from lists. Now materialized into a fresh dynamic buffer, yielding a pointer to its NUL-terminated data area, usable anywhere a text is.

- regression test 107: text from format string through list to execve
- examples/sh.vox: minimal interactive shell (tokenizer, fork/exec with /bin and /usr/bin fallback, reap) - first shell for Vox OS
- LANGUAGE.md: document format strings as values