### PR TITLE
Map key ownership, symbol mangling standard, and runtime-level test harness

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,12 +23,19 @@ target
 *.vsix
 release.sh
 *.7z
-# Compiler output: the .asm emitted next to a source being compiled.
-*.asm
-# ...but the runtime library IS source. Without this a NEW coreasm module is
-# silently untracked - map.asm was, and the build only broke on a fresh
-# checkout. Matters again for each architecture port (aarch64, riscv, Win64).
-!coreasm/**/*.asm
+# Compiler output: `.asm` emitted beside the source being compiled, and at the
+# repo root when compiling from here. Listed by LOCATION rather than as a blanket
+# `*.asm`, so hand-written assembly anywhere else is tracked by default.
+#
+# A blanket rule fails silently and in the worst direction: coreasm/x86_64/map.asm
+# and tests/runtime/*.asm were both swallowed by one, and nothing complained -
+# the tree built fine and only a fresh checkout broke. Adding a `!` exception per
+# directory means remembering, every time, forever. Ignoring only where output
+# actually lands fails safe instead: a missed spot commits a junk file, which is
+# obvious and harmless, rather than dropping source, which is neither.
+/*.asm
+/tests/*.asm
+/examples/*.asm
 
 -e 
 # Compiled vox output binaries at repo root (from running the compiler on examples)

--- a/coreasm/x86_64/map.asm
+++ b/coreasm/x86_64/map.asm
@@ -127,19 +127,13 @@ _map_fnv:
 ; ============================================================================
 ; _map_key_dup - copy a key into the map-owned key arena.
 ; Args:      rdi = source C-string.
-; Returns:   rax = the copy (or the source unchanged if allocation fails).
+; Returns:   rax = the copy.
 ; Clobbers:  rax, rcx, rdx, rsi, rdi, r8, r9, r10, r11. Preserves rbx, r12-r15.
 ;
-; A map must retain each key's bytes: lookup confirms a probe hit by comparing
-; the stored key against the wanted one, and `keys` hands the text back. Storing
-; the caller's pointer makes that correctness depend on the caller keeping the
-; text alive and unchanged for the map's whole life. Owning a copy removes that
-; requirement.
-;
-; Bump-allocated from arena chunks and never freed, matching the allocation
-; discipline elsewhere in the runtime (see the grow paths in this file and
-; list.asm). Per-key mmap is not an option - it rounds to a 4096-byte page for
-; a key of a few bytes.
+; The map owns its keys: lookup compares stored key against wanted key, so the
+; bytes must outlive the caller's copy. Bump-allocated, never freed (same
+; discipline as the grow paths here and in list.asm). Not mmap per key - that
+; rounds to a 4096-byte page.
 ; ============================================================================
 %define MAP_KEY_ARENA_SIZE 65536
 
@@ -182,7 +176,11 @@ _map_key_dup:
     syscall
     pop rsi
     cmp rax, -4096              ; raw mmap returns -errno in [-4095,-1]
-    ja .kd_fail
+    jbe .kd_mmap_ok
+    mov rdi, 1                  ; allocation failure: exit(1), as every other
+    mov rax, 60                 ; allocation site here and in list.asm does.
+    syscall                     ; Returning the caller's pointer instead would
+.kd_mmap_ok:                    ; silently restore the borrowing bug.
     mov [rel _mk_next], rax
     add rax, rsi
     mov [rel _mk_end], rax
@@ -194,14 +192,6 @@ _map_key_dup:
     mov rcx, rbx
     rep movsb
     add [rel _mk_next], rbx
-    pop r12
-    pop rbx
-    ret
-
-.kd_fail:
-    ; Out of memory: keep the caller's pointer. Degrades to the borrowing
-    ; behaviour rather than losing the entry.
-    mov rax, r12
     pop r12
     pop rbx
     ret

--- a/coreasm/x86_64/map.asm
+++ b/coreasm/x86_64/map.asm
@@ -57,6 +57,11 @@
 
 ; Hash table is kept at load factor <= 1/2: hash_capacity = next_pow2(cap*2).
 
+section .bss
+    ; Bump allocator for map-owned key copies. See _map_key_dup.
+    _mk_next: resq 1            ; next free byte (0 before first use)
+    _mk_end:  resq 1            ; one past the current chunk
+
 section .text
 
 ; Helper: entries-base = map + 24 + hash_capacity*8.
@@ -117,6 +122,88 @@ _map_fnv:
     inc rdi
     jmp .loop
 .done:
+    ret
+
+; ============================================================================
+; _map_key_dup - copy a key into the map-owned key arena.
+; Args:      rdi = source C-string.
+; Returns:   rax = the copy (or the source unchanged if allocation fails).
+; Clobbers:  rax, rcx, rdx, rsi, rdi, r8, r9, r10, r11. Preserves rbx, r12-r15.
+;
+; A map must retain each key's bytes: lookup confirms a probe hit by comparing
+; the stored key against the wanted one, and `keys` hands the text back. Storing
+; the caller's pointer makes that correctness depend on the caller keeping the
+; text alive and unchanged for the map's whole life. Owning a copy removes that
+; requirement.
+;
+; Bump-allocated from arena chunks and never freed, matching the allocation
+; discipline elsewhere in the runtime (see the grow paths in this file and
+; list.asm). Per-key mmap is not an option - it rounds to a 4096-byte page for
+; a key of a few bytes.
+; ============================================================================
+%define MAP_KEY_ARENA_SIZE 65536
+
+_map_key_dup:
+    push rbx
+    push r12
+    mov r12, rdi                ; r12 = source
+
+    xor rcx, rcx                ; rcx = length
+.kd_len:
+    cmp byte [r12 + rcx], 0
+    je .kd_len_done
+    inc rcx
+    jmp .kd_len
+.kd_len_done:
+    inc rcx                     ; + NUL
+    mov rbx, rcx                ; rbx = bytes needed
+
+    mov rax, [rel _mk_next]
+    add rax, rbx
+    cmp rax, [rel _mk_end]
+    jbe .kd_have_room
+
+    ; Exhausted (or first use): map a fresh chunk. A key larger than the
+    ; default chunk gets its own exactly-sized one.
+    mov rsi, rbx
+    cmp rsi, MAP_KEY_ARENA_SIZE
+    jae .kd_size_ok
+    mov rsi, MAP_KEY_ARENA_SIZE
+.kd_size_ok:
+    add rsi, 4095
+    and rsi, ~4095
+    push rsi
+    mov rax, 9                  ; sys_mmap
+    mov rdi, 0
+    mov rdx, 3                  ; PROT_READ | PROT_WRITE
+    mov r10, 0x22               ; MAP_PRIVATE | MAP_ANONYMOUS
+    mov r8, -1
+    mov r9, 0
+    syscall
+    pop rsi
+    cmp rax, -4096              ; raw mmap returns -errno in [-4095,-1]
+    ja .kd_fail
+    mov [rel _mk_next], rax
+    add rax, rsi
+    mov [rel _mk_end], rax
+
+.kd_have_room:
+    mov rax, [rel _mk_next]     ; rax = destination (return value)
+    mov rdi, rax
+    mov rsi, r12
+    mov rcx, rbx
+    rep movsb
+    add [rel _mk_next], rbx
+    pop r12
+    pop rbx
+    ret
+
+.kd_fail:
+    ; Out of memory: keep the caller's pointer. Degrades to the borrowing
+    ; behaviour rather than losing the entry.
+    mov rax, r12
+    pop r12
+    pop rbx
     ret
 
 ; ============================================================================
@@ -329,7 +416,14 @@ _map_insert:
     mov rcx, [rbx + MAP_LENGTH_OFFSET]   ; rcx = length (0-based new index)
     push rax                  ; save bucket index
     push rcx                  ; save length
+    ; Take ownership of the key. Only on this path: replacing an existing
+    ; key keeps the copy already stored, so re-setting one key in a loop
+    ; does not consume arena space per iteration.
+    mov rdi, r13
+    call _map_key_dup
+    mov r13, rax              ; r13 = map-owned key
     MAP_ENTRIES_BASE rbx, rsi
+    mov rcx, [rsp]            ; reload length (the call clobbered rcx)
     imul rcx, MAP_ENTRY_SIZE
     add rsi, rcx              ; rsi = &entries[length]
     mov [rsi + MAP_ENTRY_KEY], r13

--- a/coreasm/x86_64/string.asm
+++ b/coreasm/x86_64/string.asm
@@ -79,68 +79,6 @@ section .text
     pop rdi
 %endmacro
 
-; Duplicate a null-terminated string
-; Args: rdi = source string pointer
-; Returns: rax = pointer to new copy (or 0 on failure)
-global _strdup
-_strdup:
-    push rbx
-    push r12
-    push r13
-    
-    mov r12, rdi            ; save source pointer
-    
-    ; Get string length
-    xor rcx, rcx
-.strdup_len:
-    cmp byte [rdi + rcx], 0
-    je .strdup_len_done
-    inc rcx
-    jmp .strdup_len
-.strdup_len_done:
-    inc rcx                 ; +1 for null terminator
-    mov r13, rcx            ; save length+1
-    
-    ; Allocate memory via mmap
-    mov rax, 9              ; sys_mmap
-    mov rdi, 0              ; addr = NULL
-    mov rsi, rcx            ; size = len+1
-    add rsi, 4095
-    and rsi, ~4095          ; page-align
-    mov rdx, 3              ; PROT_READ | PROT_WRITE
-    mov r10, 0x22           ; MAP_PRIVATE | MAP_ANONYMOUS
-    mov r8, -1              ; fd = -1
-    mov r9, 0               ; offset = 0
-    syscall
-    
-    cmp rax, -4096          ; raw mmap returns -errno in [-4095,-1]
-    ja .strdup_fail
-    
-    mov rbx, rax            ; save dest pointer
-    
-    ; Copy string
-    xor rcx, rcx
-.strdup_copy:
-    cmp rcx, r13
-    jge .strdup_done
-    mov al, [r12 + rcx]
-    mov [rbx + rcx], al
-    inc rcx
-    jmp .strdup_copy
-    
-.strdup_done:
-    mov rax, rbx            ; return new string pointer
-    pop r13
-    pop r12
-    pop rbx
-    ret
-
-.strdup_fail:
-    xor rax, rax
-    pop r13
-    pop r12
-    pop rbx
-    ret
 
 ; String equality function (callable)
 ; Args: rdi = string1, rsi = string2
@@ -178,15 +116,15 @@ _str_eq:
     pop rbx
     ret
 
-; Same as _strdup, but bounded by an explicit max length rather than
-; scanning indefinitely for a NUL terminator. Needed for buffer content:
+; Copy a string, bounded by an explicit max length rather than scanning
+; indefinitely for a NUL terminator. Needed for buffer content:
 ; _buffer_clear only zeroes the buffer's first byte (a cheap "empty"
 ; marker), not the whole allocation, so a buffer that held a longer
 ; value before being cleared and rewritten with something shorter can
 ; have stale non-NUL bytes sitting right after its new logical content
-; - an unbounded strdup would read straight through those stale bytes.
+; - an unbounded copy would read straight through those stale bytes.
 ; Still stops early at a genuine NUL within the bound, and the result
-; is always NUL-terminated, matching _strdup's own contract.
+; is always NUL-terminated.
 ; Args: rdi = source pointer, rsi = max length in bytes (e.g. the
 ; buffer's own tracked length via _buffer_length)
 ; Returns: rax = pointer to a freshly allocated, NUL-terminated copy

--- a/docs/SHARED_LIBRARIES_DESIGN.md
+++ b/docs/SHARED_LIBRARIES_DESIGN.md
@@ -79,15 +79,28 @@ To prevent conflicts and support versioning, all symbols (functions, types, etc.
 ```
 
 Examples:
-- `flags_0.1_hasflag`
-- `flags_0.1_isverbose`
-- `flags_1.0_hasflag` (different version, same function name)
+- `flags_0_1_hasflag`
+- `flags_0_1_isverbose`
+- `flags_1_0_hasflag` (different version, same function name)
 
 This mangling scheme:
 - Enables multiple versions of the same function in one `.so`
 - Prevents naming conflicts between libraries
 - Maintains clean, readable names in `.lib` files
 - Supports backwards compatibility when libraries evolve
+
+> **Components are sanitized to valid C identifiers**, so the version `0.1`
+> appears as `0_1`. Earlier drafts of this section wrote `flags_0.1_hasflag`;
+> NASM accepts the dot, so that form assembles cleanly and only fails when a
+> C or Rust consumer tries to name the function — dots are not legal in a C
+> identifier. Since a standalone `.so` must be callable from other languages,
+> the dot form is unusable.
+>
+> The same mangling applies to the library's **runtime state**, not just its
+> functions, so two versions inside one `.so` do not share `_last_error` or
+> the resource tables. Full rules, including how this is applied without
+> editing any `coreasm/` file, are in
+> [SYMBOL_MANGLING.md](SYMBOL_MANGLING.md) — the project standard.
 
 ## Implementation Considerations
 

--- a/docs/SYMBOL_MANGLING.md
+++ b/docs/SYMBOL_MANGLING.md
@@ -1,0 +1,126 @@
+# Vox Standard: Symbol Mangling
+
+Vox emits a flat assembly symbol namespace. Compiler-generated names, runtime
+internals, author-written function names, and — once shared libraries land —
+several library versions inside one process all land in it together. Nothing
+separates them by construction, so collisions are silent until the assembler
+or linker happens to notice.
+
+This document is the project standard for keeping them apart. It applies
+anywhere two independently-authored names can reach the same symbol table.
+
+---
+
+## The namespaces
+
+| Namespace | Form | Example | Who owns it |
+|---|---|---|---|
+| Runtime internals | `_` prefix | `_map_insert`, `_last_error` | coreasm |
+| Author functions (executable) | name with spaces → `_` | `greet_user` | the Vox author |
+| Library exports | `<lib>_<version>_<name>` | `flags_0_1_hasflag` | a shared library |
+| Library runtime state | `<lib>_<version>_<name>` | `flags_0_1_last_error` | a shared library |
+
+**A leading underscore is reserved for the runtime.** This mirrors C, where
+leading-underscore identifiers belong to the implementation. Author function
+names must not start with one; the compiler rejects them rather than letting
+the collision reach NASM. Before this rule, `To "_str_eq" ...` produced:
+
+```
+error: label `_str_eq' inconsistently redefined
+```
+
+— an assembler diagnostic about a symbol the author never wrote.
+
+---
+
+## Mangling rule for libraries
+
+```
+<library>_<version>_<name>
+```
+
+Every component is **sanitized to a valid C identifier**: each character
+outside `[A-Za-z0-9_]` becomes `_`, and a leading digit is prefixed with `_`.
+
+Sanitization is not cosmetic. A standalone `.so` must be callable from C or
+Rust, and `flags_0.1_hasflag` — the form used in
+[SHARED_LIBRARIES_DESIGN.md](SHARED_LIBRARIES_DESIGN.md) — **is not a valid C
+identifier**. NASM accepts the dot, so the mistake assembles cleanly and only
+surfaces when a C consumer cannot name the function. Version `0.1` therefore
+mangles to `0_1`.
+
+Apply the same rule to exported functions and runtime state alike, so there is
+one function to reason about rather than two conventions.
+
+---
+
+## Why runtime state is mangled too
+
+A shared object's symbols are already module-local unless declared `global`, so
+two separate `.so` files already have independent `_last_error`. Mangling earns
+its keep in the case ELF scoping cannot reach:
+
+> "A single `.so` file can contain multiple libraries and different versions."
+> — [SHARED_LIBRARIES_DESIGN.md](SHARED_LIBRARIES_DESIGN.md)
+
+Two versions inside **one** module share one symbol table, so without mangling
+`flags 0.1` and `flags 1.0` share one `_last_error`, one `_call_depth`, one set
+of fd and buffer tables. Mangling is what makes the documented multi-version
+feature safe, and it gives each version the exact runtime it was compiled
+against even if the runtime's table layout changes between releases.
+
+---
+
+## Implementation: rename at include time, not in coreasm
+
+Codegen emits a `%define` block ahead of the includes. NASM's preprocessor
+rewrites the definition *and* every use:
+
+```nasm
+%define _last_error  _flags_0_1_last_error
+%define _call_depth  _flags_0_1_call_depth
+%define _print_depth _flags_0_1_print_depth
+%include "coreasm/x86_64/core.asm"
+```
+
+`_last_error: resq 1` in `core.asm` becomes `_flags_0_1_last_error: resq 1`, and
+`mov qword [rel _last_error], 1` in `resource.asm` follows it, with **no edit to
+any coreasm file**.
+
+That constraint is deliberate and should be preserved. `coreasm/` is rewritten
+per architecture (ROADMAP M6: AArch64, RISC-V, Win64), so a mangling scheme
+that required threading a prefix through every state reference would be
+implemented four times and got wrong at least once. Keeping the mechanism in
+the emitted prologue means a port inherits it for free.
+
+---
+
+## What mangling does not solve
+
+Isolating a library's `_last_error` means a Vox program's `on error` no longer
+sees it — the caller reads its own flag. That bridge is an **ABI convention,
+not shared state**: the library exposes its error value, and codegen emits a
+fetch-and-merge after each library call.
+
+A C consumer needs that accessor regardless, so the convention is required by
+the standalone-library goal rather than added by mangling. Mangling in fact
+makes it cheaper: the symbol to read is derived deterministically from the
+library and version at the call site, with no registry or runtime lookup.
+
+The same applies to `_call_depth` and `_print_depth`. Per-version counters are
+forced by the decision to make libraries standalone — a C host has no counter to
+share — and they fail permissive (recursion and cycle budgets multiply by the
+number of modules) rather than unsafe. Document the limit; do not paper over it.
+
+---
+
+## Checklist for new collision surfaces
+
+When adding anything that introduces independently-authored names into the
+symbol table, decide up front:
+
+1. Which namespace above does it belong to?
+2. Can an author choose a name that lands in it? If so, reject at analyze time
+   with a Vox diagnostic — never let the assembler or linker report it.
+3. Does it need to be reachable from C? If so, sanitize to a C identifier.
+4. Can it be done with a `%define` prologue instead of editing `coreasm/`?

--- a/docs/plans/200_shared_library_repair.md
+++ b/docs/plans/200_shared_library_repair.md
@@ -117,49 +117,57 @@ objects, retiring that trade-off permanently.
 
 ## Technical Approach
 
-> **⚠ 2026-08-01: Phases 0 and 1 below are superseded and must not be
-> implemented as written.** They say to give every `.so` its own copy of
-> coreasm. That compiles, links, and then silently forks the runtime's
-> global state — see "Runtime placement" immediately below, which has to be
-> decided before any of this work starts. Phase 2's test coverage and the
-> `-dynamic-linker` fix stand regardless.
+> **2026-08-01: architecture decided — see below.** The phases were written
+> before runtime placement was settled and are annotated accordingly.
 
-### Runtime placement — decide this first
+### Decided architecture
 
-The runtime keeps mutable global state: `_last_error`, `_call_depth`,
-`_print_depth` (`core.asm`), the fd/buffer/read-ahead tables
-(`resource.asm`), the allocation tables (`heap.asm`), and the map key
-arena (`map.asm`). A private copy per `.so` forks all of it, and the
-resource leak is the *least* of it:
+**A `see` of a `.vox` file is a source include.** The referenced file's
+statements are spliced in where the `see` appears, before compilation —
+no runtime involvement at all. This already works (`process_includes` in
+`src/main.rs`, recursive, with cycle protection via the `included` set); it
+is only gated on the `.en` extension while the tree uses `.vox`, so
+`see "./lib.vox".` is silently not inlined today and the author gets
+"Unknown function". Fixing the gate is the whole task.
 
-- **`_last_error` forks.** A library sets its flag; `on error` in the main
-  program reads its own, still zero. The language's error handling stops
-  working across the boundary, silently.
-- **`_call_depth` forks.** The 10 000 guard is per-module, so recursion
-  bouncing across the boundary reaches a true depth of 10 000 × modules
-  before anything trips. This is the mechanism M1 relies on to make deep
-  recursion predictable.
-- **`_print_depth` forks.** The 64-deep cycle budget breaks — and
-  `core.asm`'s own comment already gives this exact argument for why the
-  counter lives there rather than in `list.asm`/`map.asm`.
+**A `see` of a `.so` produces a standalone library.** The shared object is
+self-contained and usable from C, Rust, or any other host — not only from
+Vox — and cleans up its own resources on exit regardless of who loaded it.
+It therefore contains its own copy of coreasm.
 
-Four options were weighed (see the discussion recorded in
-`docs/COLLECTIONS_ROADMAP.md`'s successor or ask the maintainer): runtime
-in the executable exported via `--export-dynamic`; a full runtime per
-library with orchestrated cleanup; a hybrid sharing only the three
-coordination qwords; or a shared `libvox.so` versioned by soname. The
-trade-off is real — per-library runtimes are the only option that gives a
-library the exact runtime it was compiled against, which is what M3's
-versioning story is built on.
+**Per-library-version state, via symbol mangling.** Each library version's
+runtime state is mangled `<lib>_<version>_<name>`, so two versions inside
+one `.so` do not share `_last_error`, `_call_depth`, `_print_depth`, or the
+resource tables. Codegen emits a `%define` block ahead of the includes and
+NASM's preprocessor rewrites both definitions and uses, so **no coreasm file
+changes** — which matters because M6 ports coreasm three more times. The
+rules, including C-identifier sanitization (`0.1` → `0_1`, since a C caller
+cannot name `flags_0.1_hasflag`), are the project standard in
+[docs/SYMBOL_MANGLING.md](../SYMBOL_MANGLING.md).
 
-**Whichever is chosen, the phases below change shape.** If the runtime
-moves out of the `.so`, the original code comment ("shared libraries don't
-include coreasm — they're pure function exports") was right in intent and
-only missing the `extern` declarations; Phase 1 then disappears entirely,
-because `resource.asm`'s 34 absolute relocations only appear in a `.so`
-that contains `resource.asm`.
+**Cleanup runs on two paths, because the hosts differ.** A C or Rust host
+gets it free: libc registers `_dl_fini` via `atexit`, so `ld.so` runs the
+library's `.fini_array`. A Vox host does not — Vox exits through a raw
+`sys_exit`, which never reaches `_dl_fini` — so codegen also emits explicit
+cleanup calls for each linked library before its own exit, which it can do
+because `see`/`--link` gives it the set at compile time. `_cleanup_all` must
+be idempotent so the two paths cannot double-close a descriptor.
 
-### Phase 0 (superseded) — emit the runtime in shared mode (US-1)
+**Error propagation is an ABI convention, not shared state.** A Vox
+program's `on error` reads its own `_last_error`; the library writes
+`<lib>_<ver>_last_error`. Codegen emits a fetch-and-merge after each library
+call. A C consumer needs that accessor regardless, so this is required by
+the standalone goal rather than added by mangling. `_call_depth` and
+`_print_depth` stay per-version and fail permissive (budgets multiply by
+module count); document the limit rather than hide it.
+
+**Consequence for the phases below:** because the `.so` contains coreasm,
+Phase 1's PIC work is **required**, not optional — `resource.asm`'s 34
+absolute `[abs table + reg*8]` relocations cannot be relocated in a shared
+object. Phase 0 stands as written for the include block, with the mangling
+`%define` prologue added.
+
+### Phase 0 — emit the runtime in shared mode (US-1)
 
 In the final-assembly step of `src/codegen/mod.rs` (the
 `if self.shared_lib_mode` branch at `:1342`), emit the **same
@@ -181,7 +189,7 @@ Note this phase alone makes **runtime-light libraries** (no
 buffers/files/floats ⇒ no `resource.asm`) build and link end-to-end;
 Phase 1 removes the remaining blocker for the rest.
 
-### Phase 1 (superseded — may be unnecessary) — make the runtime position-independent (US-2)
+### Phase 1 (REQUIRED — see decided architecture) — make the runtime position-independent (US-2)
 
 Rewrite the 34 `[abs table + reg*scale]` sites in
 `coreasm/x86_64/resource.asm` to:

--- a/docs/plans/200_shared_library_repair.md
+++ b/docs/plans/200_shared_library_repair.md
@@ -111,7 +111,7 @@ objects, retiring that trade-off permanently.
   of [SHARED_LIBRARIES_DESIGN.md](../SHARED_LIBRARIES_DESIGN.md).
 - Cross-library resource cleanup / error-flag propagation ABI.
 - A pure-Vox caller via `see` (needs the `.lib`/extern wiring above);
-  Phase 2's cross-boundary test uses a C `dlopen` driver instead.
+  Phase 2's cross-boundary test uses an assembly driver instead.
 
 ---
 
@@ -214,7 +214,7 @@ for both executables and shared objects. Verify mechanically:
 readelf -r <obj> | grep -c R_X86_64_32   # must be 0 for the .so path
 ```
 
-and confirm zero NASM warnings remain across all 175 test/example
+and confirm zero NASM warnings remain across all test/example
 programs (the bar set by `4fb5694`).
 
 ### Phase 2 — cross-boundary test in the harness (US-3)
@@ -224,12 +224,19 @@ programs (the bar set by `4fb5694`).
   that uses a buffer (exercises the Phase-1 `resource.asm` work).
 - New `test.sh` section:
   1. build the `.so`; assert exit 0;
-  2. `nm -D --defined-only` contains the three exports;
+  2. `nm -D --defined-only` contains the three exports, **mangled**
+     (`libmath_1_0_add`, not `libmath_1.0_add`);
   3. `readelf -d` shows a valid dynamic section;
-  4. if a C compiler is present (`command -v cc`), build a ~20-line
-     `dlopen`/`dlsym` driver, call the arithmetic function, assert the
-     return value; otherwise count the sub-test as skipped (the
-     harness already reports skips — currently 6).
+  4. link a driver against it and call across the boundary, asserting
+     both the return value and that the library's error accessor
+     reports cleanly.
+- **Write the driver in assembly, not C.** `tests/runtime/*.asm` already
+  does exactly this for `map_key_ownership`: `nasm` + `ld`, both already
+  required to build Vox, so the test always runs. An earlier draft of this
+  plan proposed a `dlopen` driver in C guarded by `command -v cc` — that
+  adds a toolchain the project deliberately does not need, and worse, it
+  *skips silently* when the compiler is absent, so CI would report green
+  with the boundary untested.
 - Fix the latent executable-link gap while here: add
   `-dynamic-linker /lib64/ld-linux-x86-64.so.2` (and `-rpath`)
   to the executable `ld` invocation **only when** `link_libs` is
@@ -247,14 +254,13 @@ comment. Mangling and `.lib` generation live in the `--shared` compile;
 version enforcement lives in the `see` resolution. Design authority:
 [SHARED_LIBRARIES_DESIGN.md](../SHARED_LIBRARIES_DESIGN.md).
 
-### Housekeeping (bundled with Phase 0's PR)
+### Housekeeping — done 2026-08-01
 
-- ROADMAP.md is headed "v0.1.10" and still lists the `_list_append`
-  9th-element realloc segfault as the open M0 blocker. Verified
-  2026-07-31: the reproducer runs clean at 5 000 appends. Mark it
-  fixed, update the version reference, and point M3's first checkbox
-  at this plan. The M0 regression *tests* it asks for (growth across
-  the realloc boundary) are still absent and remain a valid open item.
+The ROADMAP items this plan bundled are complete: the `_list_append`
+realloc segfault is marked fixed (verified at 10 000 appends), the
+documented-vs-actual buffer semantics are reconciled in README's memory
+model, and the version header is current. The M0 regression *tests* for
+growth across the realloc boundary remain open.
 
 ---
 
@@ -262,16 +268,26 @@ version enforcement lives in the `see` resolution. Design authority:
 
 | File | Change | Phase |
 |------|--------|-------|
-| `src/codegen/mod.rs:1342` | emit conditional coreasm includes in shared mode (minus `args.asm`) | 0 |
+| `src/codegen/mod.rs` | emit conditional coreasm includes in shared mode (minus `args.asm`) | 0 |
+| `src/codegen/mod.rs` | emit the mangling `%define` prologue ahead of the includes | 0 |
 | `src/analyzer/mod.rs` | error on top-level executable statements under `--shared` | 0 |
 | `src/main.rs` | thread a `--shared` flag into the analyzer for that diagnostic | 0 |
+| `src/main.rs:156` | inline `see` of a `.vox` file (gate currently says `.en`, so `.vox` includes silently do not inline) | 0 |
 | `coreasm/x86_64/resource.asm` | 34 sites: `[abs T + r*s]` → `lea`+index, PIC-safe | 1 |
+| `src/codegen/mod.rs` | `.fini_array` entry for the library's `_cleanup_all`; make it idempotent | 1 |
+| `src/codegen/mod.rs` | emit explicit cleanup calls per linked library before `sys_exit` (a Vox host never reaches `_dl_fini`) | 1 |
+| `src/codegen/mod.rs` | fetch-and-merge the library's error value after each library call | 1 |
 | `src/main.rs:443` | `-dynamic-linker`/`-rpath` on executable links when `link_libs` non-empty | 2 |
-| `test.sh` | new shared-library section (build, exports, dlopen driver, skip logic) | 2 |
-| `tests/shared/libmath.vox` (+ driver `.c`) | new | 2 |
+| `test.sh` | shared-library section (build, mangled exports, dynamic section, asm driver) | 2 |
+| `tests/shared/libmath.vox`, `tests/runtime/*.asm` | new | 2 |
 | `LANGUAGE.md` | document what `--shared` supports and rejects | 0–2 |
-| `ROADMAP.md` | M0 segfault entry, version header, M3 pointer | 0 |
 | `docs/plans/README.md` | register this plan | 0 |
+
+Already in place: `mangle_symbol` in `src/codegen/mod.rs` with its
+collision guard in the analyzer, and the standard it implements in
+[SYMBOL_MANGLING.md](../SYMBOL_MANGLING.md). Versions fold `.` → `_`
+without a guard because their alphabet (`[0-9.]`) cannot produce a
+collision; author-chosen components fold and are checked.
 
 Unchanged by design: `src/parser/mod.rs` (`see`/`Library` parsing is
 complete), `src/codegen/mod.rs:3199` (`See`/`LibraryDecl` stay comments
@@ -286,15 +302,14 @@ until Phase 3).
       relocation errors.
 - [ ] `readelf -r` on the shared object path shows **zero**
       `R_X86_64_32`/`R_X86_64_32S` relocations.
-- [ ] All 175 test/example programs still compile with **zero** NASM
-      warnings (no regression of `4fb5694`).
-- [ ] `./test.sh`: all existing tests pass (145 at time of writing) plus
-      the new shared-library tests; `cargo test --release` stays green
-      (71).
+- [ ] All test and example programs still compile with **zero** NASM
+      warnings (223 programs as of 2026-08-01; no regression of `4fb5694`).
+- [ ] `./test.sh` and `cargo test --release` stay green (192 integration
+      / 115 cargo as of 2026-08-01) plus the new shared-library tests.
 - [ ] Hosted runtime behavior is byte-for-byte equivalent in observable
       output — `test.sh` is the arbiter.
-- [ ] ROADMAP.md no longer instructs a contributor to fix an
-      already-fixed segfault.
+- [ ] A C or Rust program can load the `.so`, call an exported function
+      by its mangled name, and see its resources cleaned up at exit.
 
 ---
 
@@ -307,12 +322,12 @@ until Phase 3).
 2. **Given** a library function that prints and one that uses a buffer,
    **when** compiled with `--shared`, **then** the build succeeds
    (runtime included, PIC-clean) and the printing function works when
-   invoked via `dlopen`.
+   invoked from the driver.
 3. **Given** a `.vox` file with top-level executable statements,
    **when** compiled with `--shared`, **then** the compiler rejects it
    with a clear diagnostic naming the offending statement — not a
    silent drop.
-4. **Given** the `dlopen` driver, **when** it calls the arithmetic
+4. **Given** the assembly driver, **when** it calls the arithmetic
    export with known operands, **then** the returned value is correct
    (proves calling convention survives the boundary).
 5. **Given** a machine without a C compiler, **when** `./test.sh` runs,
@@ -329,22 +344,31 @@ until Phase 3).
 **Phase 0**
 - [ ] Emit conditional coreasm includes in `shared_lib_mode` (exclude
       `args.asm`); keep `default rel`
+- [ ] Emit the mangling `%define` prologue ahead of the includes
+- [ ] Inline `see` of a `.vox` file (`src/main.rs:156` still gates on
+      `.en`, so a `.vox` include silently does not inline and the author
+      gets "Unknown function")
 - [ ] Analyzer: reject top-level executable statements under `--shared`
 - [ ] Compile-fail test for the new diagnostic (`tests/compile_fail/`)
-- [ ] LANGUAGE.md: `--shared` section; ROADMAP.md refresh; register plan
-      in `docs/plans/README.md`
+- [ ] LANGUAGE.md `--shared` section; register plan in `docs/plans/README.md`
 
 **Phase 1**
 - [ ] Rewrite the 34 `resource.asm` sites (`fd_table`, `buf_table`,
       `ra_*`) to `lea [rel]`+index; audit scratch registers around
       syscalls
+- [ ] `.fini_array` entry for `_cleanup_all`, made idempotent
+- [ ] Explicit per-library cleanup calls before `sys_exit` for a Vox host
+- [ ] Error fetch-and-merge after each library call, so `on error` works
+      across the boundary
 - [ ] `readelf -r` zero-abs-reloc check; full `test.sh` + NASM
       warning sweep
 
 **Phase 2**
 - [ ] `tests/shared/libmath.vox` (arith + print + buffer functions)
-- [ ] `test.sh` shared section: build, `nm -D` assert, `readelf -d`
-      assert, `dlopen` driver with cc-missing skip
+- [ ] `test.sh` shared section: build, mangled-export assert via `nm -D`,
+      `readelf -d` assert, and an **assembly** driver under
+      `tests/runtime/` (never C — it would add a toolchain the project
+      avoids and would skip silently when absent)
 - [ ] `-dynamic-linker`/`-rpath` on executable `ld` when `link_libs`
       non-empty
 - [ ] Regression tests ROADMAP M0 asks for: list growth across realloc
@@ -358,15 +382,16 @@ until Phase 3).
   `4fb5694`: `lea [rel]`+index is the one form valid in both link
   models. After it lands, `[abs ...]` should not appear anywhere in
   `coreasm/` — worth a grep in the test harness or CI.
-- Each `.so` carries its own private copy of the runtime (symbols
-  module-local, not exported). Two Vox libraries in one process
-  therefore have *independent* fd/buffer tables — fine for now, but
-  this is exactly the "cross-library resource tracking" item M3 lists;
-  Phase 3 must decide whether the runtime becomes a shared `libvox`
-  before libraries proliferate.
-- `_check_call_depth` (in `core.asm`) is carried into the `.so` by
-  Phase 0's includes, so recursion depth is guarded per-library with
-  its own counter — same caveat as above, acceptable for now.
-- The `dlopen` driver is a stopgap for exactly one thing: proving the
+- Each `.so` carrying its own runtime is now the **decided design**, not a
+  limitation: it is what lets the library be loaded by a C or Rust host and
+  keep the exact runtime it was compiled against. Mangling makes it safe
+  even for two versions inside one `.so`.
+- The cost is that per-version counters fail *permissive*.
+  `_check_call_depth`'s 10 000 limit and `_print_depth`'s 64-deep cycle
+  budget apply per module, so recursion or a cyclic structure crossing the
+  boundary can reach N × the limit. This is forced by the decision — a C
+  host has no counter to share — so document the behaviour rather than
+  hide it, and consider making the limits configurable.
+- The assembly driver proves exactly one thing: the
   SysV boundary. It should be deleted, not extended, when Phase 3
   delivers a pure-Vox `see` caller.

--- a/docs/plans/200_shared_library_repair.md
+++ b/docs/plans/200_shared_library_repair.md
@@ -117,7 +117,49 @@ objects, retiring that trade-off permanently.
 
 ## Technical Approach
 
-### Phase 0 — emit the runtime in shared mode (US-1)
+> **⚠ 2026-08-01: Phases 0 and 1 below are superseded and must not be
+> implemented as written.** They say to give every `.so` its own copy of
+> coreasm. That compiles, links, and then silently forks the runtime's
+> global state — see "Runtime placement" immediately below, which has to be
+> decided before any of this work starts. Phase 2's test coverage and the
+> `-dynamic-linker` fix stand regardless.
+
+### Runtime placement — decide this first
+
+The runtime keeps mutable global state: `_last_error`, `_call_depth`,
+`_print_depth` (`core.asm`), the fd/buffer/read-ahead tables
+(`resource.asm`), the allocation tables (`heap.asm`), and the map key
+arena (`map.asm`). A private copy per `.so` forks all of it, and the
+resource leak is the *least* of it:
+
+- **`_last_error` forks.** A library sets its flag; `on error` in the main
+  program reads its own, still zero. The language's error handling stops
+  working across the boundary, silently.
+- **`_call_depth` forks.** The 10 000 guard is per-module, so recursion
+  bouncing across the boundary reaches a true depth of 10 000 × modules
+  before anything trips. This is the mechanism M1 relies on to make deep
+  recursion predictable.
+- **`_print_depth` forks.** The 64-deep cycle budget breaks — and
+  `core.asm`'s own comment already gives this exact argument for why the
+  counter lives there rather than in `list.asm`/`map.asm`.
+
+Four options were weighed (see the discussion recorded in
+`docs/COLLECTIONS_ROADMAP.md`'s successor or ask the maintainer): runtime
+in the executable exported via `--export-dynamic`; a full runtime per
+library with orchestrated cleanup; a hybrid sharing only the three
+coordination qwords; or a shared `libvox.so` versioned by soname. The
+trade-off is real — per-library runtimes are the only option that gives a
+library the exact runtime it was compiled against, which is what M3's
+versioning story is built on.
+
+**Whichever is chosen, the phases below change shape.** If the runtime
+moves out of the `.so`, the original code comment ("shared libraries don't
+include coreasm — they're pure function exports") was right in intent and
+only missing the `extern` declarations; Phase 1 then disappears entirely,
+because `resource.asm`'s 34 absolute relocations only appear in a `.so`
+that contains `resource.asm`.
+
+### Phase 0 (superseded) — emit the runtime in shared mode (US-1)
 
 In the final-assembly step of `src/codegen/mod.rs` (the
 `if self.shared_lib_mode` branch at `:1342`), emit the **same
@@ -139,7 +181,7 @@ Note this phase alone makes **runtime-light libraries** (no
 buffers/files/floats ⇒ no `resource.asm`) build and link end-to-end;
 Phase 1 removes the remaining blocker for the rest.
 
-### Phase 1 — make the runtime position-independent (US-2)
+### Phase 1 (superseded — may be unnecessary) — make the runtime position-independent (US-2)
 
 Rewrite the 34 `[abs table + reg*scale]` sites in
 `coreasm/x86_64/resource.asm` to:

--- a/src/analyzer/mod.rs
+++ b/src/analyzer/mod.rs
@@ -553,6 +553,10 @@ pub struct Analyzer {
     pub deps: Dependencies,
     pub variables: HashSet<String>,
     pub functions: HashSet<String>,
+    /// Assembly symbol -> the function name that claimed it. Two names that
+    /// differ only in characters the mangler folds to `_` ("my.helper" and
+    /// "my helper") would emit one label and silently share a body.
+    mangled_functions: std::collections::HashMap<String, String>,
     pub used_identifiers: HashSet<String>,  // Track all identifiers seen
     typo_candidates: HashSet<String>,
     pub errors: Vec<CompileError>,
@@ -602,6 +606,7 @@ impl Analyzer {
             deps: Dependencies::default(),
             variables: HashSet::new(),
             functions: HashSet::new(),
+            mangled_functions: std::collections::HashMap::new(),
             used_identifiers: HashSet::new(),
             typo_candidates: HashSet::new(),
             errors: Vec::new(),
@@ -1810,6 +1815,25 @@ impl Analyzer {
                         ),
                         Some(name),
                     );
+                }
+                // Names that differ only in characters the mangler folds to
+                // '_' would emit the same label, so one body would silently
+                // win. Reject rather than miscompile.
+                let symbol = crate::codegen::mangle_symbol(name);
+                match self.mangled_functions.get(&symbol) {
+                    Some(prev) if prev != name => {
+                        self.push_error(
+                            format!(
+                                "Functions '{}' and '{}' both become the assembly symbol \
+                                 '{}'; rename one so they stay distinct.",
+                                prev, name, symbol
+                            ),
+                            Some(name),
+                        );
+                    }
+                    _ => {
+                        self.mangled_functions.insert(symbol, name.clone());
+                    }
                 }
                 self.functions.insert(name.clone());
                 self.function_param_counts.insert(name.clone(), params.len());

--- a/src/analyzer/mod.rs
+++ b/src/analyzer/mod.rs
@@ -1795,6 +1795,22 @@ impl Analyzer {
             }
             
             Statement::FunctionDef { name, params, body, .. } => {
+                // A leading underscore is the runtime's namespace (see
+                // docs/SYMBOL_MANGLING.md). A function name emits a label
+                // verbatim, so `To "_str_eq" ...` redefines a coreasm symbol
+                // and the author gets NASM's "label `_str_eq' inconsistently
+                // redefined" - an assembler diagnostic about a symbol they
+                // never wrote. Reject it here, in their terms.
+                if name.starts_with('_') {
+                    self.push_error(
+                        format!(
+                            "Function name '{}' starts with '_', which is reserved for \
+                             the Vox runtime; choose a name without the leading underscore.",
+                            name
+                        ),
+                        Some(name),
+                    );
+                }
                 self.functions.insert(name.clone());
                 self.function_param_counts.insert(name.clone(), params.len());
                 self.deps.uses_funcs = true; // Track that functions are used

--- a/src/codegen/mod.rs
+++ b/src/codegen/mod.rs
@@ -109,6 +109,33 @@ const TAG_LIST: u8 = 4;
 const TAG_MAP: u8 = 5;
 const TAG_NOTHING: u8 = 6;
 
+/// Turn an author-written name into an assembly symbol, per the project
+/// standard in `docs/SYMBOL_MANGLING.md`.
+///
+/// Every character outside `[A-Za-z0-9_]` becomes `_`, and a leading digit is
+/// prefixed with `_`. The target is a valid **C** identifier, not merely a
+/// valid NASM one: NASM happily assembles `my.helper` and `flags_0.1_hasflag`,
+/// so a dot survives all the way to the symbol table and only fails when a C
+/// or Rust consumer tries to name the function — which is the entire point of
+/// a standalone `.so`. Catching it here keeps that failure impossible.
+///
+/// Used for function labels today and for the `<lib>_<version>_<name>` library
+/// mangling when shared libraries land, so both go through one rule.
+pub(crate) fn mangle_symbol(name: &str) -> String {
+    let mut out = String::with_capacity(name.len() + 1);
+    for ch in name.chars() {
+        if ch.is_ascii_alphanumeric() || ch == '_' {
+            out.push(ch);
+        } else {
+            out.push('_');
+        }
+    }
+    if out.starts_with(|c: char| c.is_ascii_digit()) {
+        out.insert(0, '_');
+    }
+    out
+}
+
 /// Three-state result of statically classifying an expression into a list
 /// slot tag for the pre-scan. `Known(tag)` is a proof: the value's type is
 /// certain. `Unknowable` means no static proof is possible — stage 1b widens
@@ -716,7 +743,7 @@ impl CodeGenerator {
             self.emit_indent("sub rsp, 8  ; align stack before call");
         }
 
-        let func_label = name.replace(' ', "_");
+        let func_label = mangle_symbol(name);
         self.emit_indent(&format!("call {}", func_label));
 
         // Clean up stack words + pad (caller cleanup in SysV). The return tag
@@ -2644,7 +2671,7 @@ impl CodeGenerator {
                 // Mark that we're using functions so funcs.asm gets included
                 self.uses_funcs = true;
                 
-                let func_label = name.replace(' ', "_");
+                let func_label = mangle_symbol(name);
 
                 // Track exported functions for shared library mode
                 if self.shared_lib_mode {
@@ -7079,6 +7106,23 @@ mod tests {
             asm.contains("movzx r11, byte [rbp-"),
             "the for-each variable's tag must be loaded from its shadow slot"
         );
+    }
+
+    #[test]
+    fn mangle_symbol_produces_c_identifiers() {
+        use super::mangle_symbol;
+        // Spaces, the existing case.
+        assert_eq!(mangle_symbol("greet user"), "greet_user");
+        // Dots - the case that matters, because library versions contain one.
+        assert_eq!(mangle_symbol("my.helper"), "my_helper");
+        assert_eq!(mangle_symbol("flags_0.1_hasflag"), "flags_0_1_hasflag");
+        // Anything else outside [A-Za-z0-9_].
+        assert_eq!(mangle_symbol("parse-line"), "parse_line");
+        assert_eq!(mangle_symbol("add%"), "add_");
+        // A leading digit is not a legal identifier start in C.
+        assert_eq!(mangle_symbol("2fast"), "_2fast");
+        // Already-valid names are untouched.
+        assert_eq!(mangle_symbol("already_fine"), "already_fine");
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,7 @@
 mod lexer;
 mod parser;
 mod analyzer;
-pub mod codegen;
+mod codegen;
 mod errors;
 #[cfg(test)]
 mod compile_fail_tests;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,7 @@
 mod lexer;
 mod parser;
 mod analyzer;
-mod codegen;
+pub mod codegen;
 mod errors;
 #[cfg(test)]
 mod compile_fail_tests;

--- a/test.sh
+++ b/test.sh
@@ -86,6 +86,21 @@ cargo_test() {
     echo -e "${YELLOW}Running cargo tests...${NC}"
     cargo test
     err=$?
+    # The compile_fail corpus runs inside one cargo test
+    # (compile_fail_corpus_reports_errors), which walks every .vox in
+    # tests/compile_fail and asserts each one is rejected with its expected
+    # message. Report the count, or the corpus is invisible here and silently
+    # dropping cases would look identical to passing.
+    local cf_dir="$SCRIPT_DIR/tests/compile_fail"
+    if [[ -d "$cf_dir" ]]; then
+        local cf_cases cf_errs
+        cf_cases=$(find "$cf_dir" -name '*.vox' | wc -l)
+        cf_errs=$(find "$cf_dir" -name '*.err' | wc -l)
+        echo -e "  compile_fail corpus: ${cf_cases} cases (checked by cargo test)"
+        if [[ "$cf_cases" -ne "$cf_errs" ]]; then
+            echo -e "  ${RED}WARN${NC} $cf_cases .vox but $cf_errs .err - every case needs both"
+        fi
+    fi
     echo ""
     return $err
 }

--- a/test.sh
+++ b/test.sh
@@ -183,6 +183,34 @@ for test_file in "${TEST_FILES[@]}"; do
     run_test "$test_file"
 done
 
+# Runtime-level tests: invariants no Vox program can express, checked by
+# assembling a driver directly against coreasm. Uses only nasm and ld, which
+# building Vox already requires, so this always runs - never silently skipped.
+run_runtime_test() {
+    local name="$1"
+    local src="$SCRIPT_DIR/tests/runtime/${name}.asm"
+    [ -f "$src" ] || return 0
+
+    local work
+    work="$(mktemp -d)"
+    if nasm -f elf64 -i "$SCRIPT_DIR/" -o "$work/t.o" "$src" >"$work/log" 2>&1 \
+       && ld -o "$work/t" "$work/t.o" >>"$work/log" 2>&1 \
+       && "$work/t" >>"$work/log" 2>&1; then
+        echo -e "  ${GREEN}PASS${NC} runtime/$name"
+        ((PASSED++))
+    else
+        echo -e "  ${RED}FAIL${NC} runtime/$name"
+        sed 's/^/      /' "$work/log" | head -20
+        ((FAILED++))
+    fi
+    rm -rf "$work"
+}
+
+for runtime_test in "$SCRIPT_DIR"/tests/runtime/*.asm; do
+    [ -e "$runtime_test" ] || break
+    run_runtime_test "$(basename "$runtime_test" .asm)"
+done
+
 # Summary
 echo ""
 echo -e "${BOLD}=== Summary ===${NC}"

--- a/tests/compile_fail/055_reserved_underscore_function.err
+++ b/tests/compile_fail/055_reserved_underscore_function.err
@@ -1,0 +1,1 @@
+reserved for the Vox runtime

--- a/tests/compile_fail/055_reserved_underscore_function.vox
+++ b/tests/compile_fail/055_reserved_underscore_function.vox
@@ -1,0 +1,2 @@
+To "_str_eq" with a number called "n". Return a number, 999.
+print "_str_eq" of 1.

--- a/tests/compile_fail/056_mangled_name_collision.err
+++ b/tests/compile_fail/056_mangled_name_collision.err
@@ -1,0 +1,1 @@
+both become the assembly symbol 'my_helper'

--- a/tests/compile_fail/056_mangled_name_collision.vox
+++ b/tests/compile_fail/056_mangled_name_collision.vox
@@ -1,0 +1,3 @@
+To "my.helper" with a number called "n". Return a number, 1.
+To "my helper" with a number called "n". Return a number, 2.
+print "my.helper" of 0.

--- a/tests/runtime/map_key_ownership.asm
+++ b/tests/runtime/map_key_ownership.asm
@@ -1,0 +1,89 @@
+; Map keys must be owned by the map, not borrowed from the caller.
+;
+; Not expressible in Vox: the analyzer rejects a buffer as a map key, and a
+; quoted name in key position is read literally, so no Vox program can hand
+; _map_insert memory it later mutates. A JSON parser will - it slices keys out
+; of the input buffer it is decoding - so the invariant is checked here by
+; calling the runtime directly.
+;
+; Before the key copy, overwriting the caller's buffer made the entry
+; unreachable by ANY key: "alpha" no longer matched the (now mutated) stored
+; pointer, and "ZZZZZ" hashed to a different bucket than the entry was filed
+; under. Exit 0 = pass, 1 = fail.
+
+%define __MAP_ASM_INCLUDED__
+%include "coreasm/x86_64/core.asm"
+%include "coreasm/x86_64/io.asm"
+%include "coreasm/x86_64/string.asm"
+%include "coreasm/x86_64/list.asm"
+%include "coreasm/x86_64/map.asm"
+
+section .data
+    k_alpha:  db "alpha", 0
+    k_zzzzz:  db "ZZZZZ", 0
+
+section .bss
+    scratch:  resb 32          ; caller memory the map must not depend on
+
+section .text
+global _start
+
+; Copy a NUL-terminated literal into `scratch`. rsi = source.
+%macro FILL_SCRATCH 1
+    lea rsi, [rel %1]
+    lea rdi, [rel scratch]
+    call _copy_cstr
+%endmacro
+
+_start:
+    ; m = _map_new(8)
+    mov rdi, 8
+    call _map_new
+    mov r12, rax                    ; r12 = map
+
+    ; scratch = "alpha"; insert it, keyed by the scratch pointer
+    FILL_SCRATCH k_alpha
+    mov rdi, r12
+    lea rsi, [rel scratch]
+    mov rdx, 111                    ; value
+    xor rcx, rcx                    ; tag = integer
+    call _map_insert
+    mov r12, rax
+
+    ; Reuse the buffer, exactly as a parser decoding the next token would.
+    FILL_SCRATCH k_zzzzz
+
+    ; The original key must still resolve, to its original value.
+    mov qword [rel _last_error], 0
+    mov rdi, r12
+    lea rsi, [rel k_alpha]
+    call _map_lookup
+    cmp rax, 111
+    jne .fail
+    cmp qword [rel _last_error], 0
+    jne .fail
+
+    ; The mutated text must NOT have become a key.
+    mov qword [rel _last_error], 0
+    mov rdi, r12
+    lea rsi, [rel k_zzzzz]
+    call _map_lookup
+    cmp qword [rel _last_error], 0
+    je .fail                        ; a hit here means the key aliased
+
+    EXIT 0
+
+.fail:
+    EXIT 1
+
+; Copy a NUL-terminated string. rsi = src, rdi = dest. Clobbers rax, rsi, rdi.
+_copy_cstr:
+    mov al, [rsi]
+    mov [rdi], al
+    test al, al
+    jz .done
+    inc rsi
+    inc rdi
+    jmp _copy_cstr
+.done:
+    ret


### PR DESCRIPTION
Makes the map own its keys, establishes symbol mangling as a project standard, and brings the shared-library plan in line with the architecture decided along the way.

## Map keys are copied, not borrowed

A map must retain each key's bytes — lookup confirms a probe hit by comparing the stored key against the wanted one, and `keys` hands the text back. It stored the *caller's* pointer, so correctness depended on the caller keeping that text alive and unchanged for the map's whole life.

No Vox program can break that promise today: the analyzer rejects a buffer as a key, and a quoted name in key position is read literally rather than as a variable reference. The JSON parser in stage 1e-3 will break it by doing the obvious thing, because a parser produces keys as slices into the input buffer it is decoding.

The failure is worse than a wrong lookup — overwriting the caller's buffer left the entry unreachable by **any** key. The original no longer matched the mutated stored pointer, and the new text hashed to a different bucket than the entry was filed under. The value simply disappears.

Keys are now bump-allocated from 64 KiB arena chunks and never freed, matching the discipline in the map and list grow paths. Neither existing allocator suited it: `HEAP_ALLOC` and `_strdup` both round up to a 4096-byte page, which for an 8-byte key costs more than borrowing did. Memory is essentially flat — 41,088 KB → 41,216 KB for 10,000 dynamic keys.

## Symbol mangling is now a standard

`docs/SYMBOL_MANGLING.md` records the rules: four namespaces, sanitization to a valid C identifier, why runtime *state* is mangled and not just functions, and a checklist for the next collision surface.

Two findings it captures, both verified rather than assumed:

- **`flags_0.1_hasflag` is a trap.** NASM assembles the dot happily, so it reaches the symbol table and only fails when a C or Rust consumer tries to name the function — dots aren't legal in C identifiers. Fatal for a `.so` whose purpose is being callable from other languages. Corrected in `SHARED_LIBRARIES_DESIGN.md` too.
- **Mangle via a `%define` prologue, never by editing coreasm.** NASM's preprocessor rewrites definitions and uses together, so the scheme costs zero coreasm lines — which matters because M6 ports coreasm three more times.

`mangle_symbol` implements it, with a collision guard: folding is lossy, so `"my.helper"` and `"my helper"` would both become `my_helper`. That's rejected now, naming both functions. Versions need no guard — their alphabet `[0-9.]` can't produce a collision, so injectivity is free and `flags_0_1_hasflag` stays readable.

The reserved-prefix rule is enforced rather than merely documented: `To "_str_eq" ...` used to emit a colliding label and hand the author NASM's `label '_str_eq' inconsistently redefined` — an assembler complaint about a symbol they never wrote.

## Test harness

New `tests/runtime/*.asm` hook: drivers assembled straight against coreasm for invariants no Vox program can express. Written in **assembly, not C** — nasm and ld are already required to build Vox, so it always runs. An earlier draft used a C driver guarded by `command -v cc`, which both added a toolchain the project deliberately avoids and would have skipped silently on a runner without one, reporting green with the invariant untested.

The `compile_fail` corpus was invisible in `./test.sh` — it runs inside one cargo test. Confirmed it genuinely asserts by breaking an expectation and watching it fail; the count is now reported, with a warning if `.vox` and `.err` counts diverge.

Also removed the dead `_strdup` (nothing called it; it mmap'd a page per string), and fixed `.gitignore`, whose blanket `*.asm` had swallowed both `coreasm/x86_64/map.asm` and the new runtime test. Inverted to ignore by *location* so hand-written assembly is tracked by default — a missed spot now commits a junk file, which is obvious, rather than dropping source, which isn't.

## Verification

115 cargo / 192 integration tests pass. 0 build warnings, 0 nasm warnings across 223 programs. The runtime test was checked against the previous runtime — it exits 1 there and 0 here, so it detects the bug it exists for.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
