### PR TITLE
Revise plan 200 so it can be implemented as written

### DIFF
--- a/docs/plans/200_shared_library_repair.md
+++ b/docs/plans/200_shared_library_repair.md
@@ -36,7 +36,7 @@ front-end syntax that was built for it (`Library ... version ...`,
 
 **Current Behavior:**
 
-1. **No runtime is emitted.** `src/codegen/mod.rs:1342` skips every
+1. **No runtime is emitted.** `src/codegen/mod.rs:2043` skips every
    `%include "coreasm/..."` line in shared mode, on the comment
    "Shared libraries don't include coreasm - they're pure function
    exports". The premise is false: function bodies are emitted using
@@ -54,9 +54,11 @@ front-end syntax that was built for it (`Library ... version ...`,
    ```
 
 2. **The runtime is not position-independent.** With the includes
-   restored by hand, NASM passes but `ld -shared` refuses with exactly
-   **34 relocation errors**, all `R_X86_64_32S against .bss`, all from
-   `coreasm/x86_64/resource.asm`. Every one is the indexed-table
+   restored by hand, NASM passes but `ld -shared` refuses. Re-verified
+   2026-08-01 against a hand-built probe (`core` + `io` + `resource` +
+   `int` + `string`): `readelf -r` reports **exactly 34** relocations,
+   every one `R_X86_64_32S` against `.bss`, every one from
+   `coreasm/x86_64/resource.asm`. Each is the indexed-table
    pattern `[abs table + reg*scale]` against the seven resource tables:
    `fd_table`, `buf_table`, `ra_used`, `ra_fd`, `ra_pos`, `ra_filled`,
    `ra_data`. x86-64 RIP-relative addressing cannot take an index
@@ -66,11 +68,14 @@ front-end syntax that was built for it (`Library ... version ...`,
 
 3. **`LibraryDecl` and `See` compile to comments.** The parser fully
    supports all four `see` syntaxes plus `Library "x" version "y"`
-   (`src/parser/mod.rs:3746`, `:3848`), but the analyzer treats both as
-   no-ops (`src/analyzer/mod.rs:2142`) and codegen emits them as
-   assembly comments (`src/codegen/mod.rs:3199`). Name mangling,
-   `.lib` metadata, and version enforcement from the design doc are
-   entirely unbuilt.
+   (`src/parser/mod.rs:3810`, `:3839`), but the analyzer treats both as
+   no-ops (`src/analyzer/mod.rs:2293`, `:2297`) and codegen emits them
+   as assembly comments (`src/codegen/mod.rs:4119`, `:4125`). Name
+   mangling, `.lib` metadata, and version enforcement from the design
+   doc are entirely unbuilt. Note that `LibraryDecl`'s name and version
+   are consumed inline in the statement walk and never stored on the
+   generator — anything that needs them in the file header must capture
+   them first.
 
 4. **Latent, discovered while investigating:** the executable `--link`
    path (`src/main.rs:443`) passes `-L`/`-l` to `ld` but never sets
@@ -78,6 +83,30 @@ front-end syntax that was built for it (`Library ... version ...`,
    against a `.so` would have no `PT_INTERP` and fail at exec. Cannot
    bite anyone today because no `.so` can be produced; must be fixed by
    the phase that first links one.
+
+5. **The whole runtime is `global`, so it would be exported.**
+   Discovered 2026-08-01 while validating this plan. **54 coreasm
+   symbols** carry an explicit `global` declaration — 29 in
+   `resource.asm`, 12 in `args.asm`, 9 across `string.asm`/`int.asm`/
+   `float.asm`, plus `funcs.asm`'s macro-generated one. Every one lands
+   in `.dynsym`. The runtime-light probe (which links today with only
+   the Phase-0 include fix) exports:
+
+   ```
+   $ nm -D --defined-only probe.so
+   _mem_eq  _parse_i64  _parse_i64_bounded  _parse_int_radix
+   _parse_int_radix_bounded  _strdup_bounded  _str_eq  _str_len
+   _text_to_boolean  vox_add
+   ```
+
+   Nine runtime symbols for one exported function. This is a namespace
+   leak, not merely untidy output: a host that `dlopen`s with
+   `RTLD_GLOBAL`, or two Vox `.so`s loaded together, collide on generic
+   names like `_str_len`. Phase 0 must close it — see the visibility
+   task there. (Measured, so the plan does not overstate it: intra-
+   library calls bound *directly* in the probe — zero `JUMP_SLOT`
+   relocations — so internal calls are not themselves interposable.
+   The defect is the exported namespace, not the internal call path.)
 
 **Expected Behavior (after Phases 0–2):**
 
@@ -146,6 +175,22 @@ rules, including C-identifier sanitization (`0.1` → `0_1`, since a C caller
 cannot name `flags_0.1_hasflag`), are the project standard in
 [docs/SYMBOL_MANGLING.md](../SYMBOL_MANGLING.md).
 
+> **Sequencing (decided 2026-08-01): mangling lands in Phase 3, not Phase 0.**
+> The architecture above is unchanged — only *when* it is built moves. Its
+> precondition is two library versions inside one `.so`, which requires the
+> `.lib` metadata and multi-library parsing that are already Out of Scope
+> until Phase 3. Phases 0–2 compile exactly one library per `.so`, where
+> there is no second version to collide with, and the symbol-visibility fix
+> in Phase 0 solves the cross-`.so` collision problem *more* completely by
+> removing runtime symbols from `.dynsym` altogether rather than making them
+> uniquely named but still exported. Building the `%define` prologue early
+> would also mean answering two questions Phase 0 has no basis to answer:
+> where the name and version come from when a file has no `Library`
+> declaration, and which of the runtime's symbols are in the mangled set.
+> Phase 3 has a real answer to both. `mangle_symbol` and
+> [SYMBOL_MANGLING.md](../SYMBOL_MANGLING.md) stay exactly as they are and
+> continue to govern function labels today.
+
 **Cleanup runs on two paths, because the hosts differ.** A C or Rust host
 gets it free: libc registers `_dl_fini` via `atexit`, so `ld.so` runs the
 library's `.fini_array`. A Vox host does not — Vox exits through a raw
@@ -165,20 +210,39 @@ module count); document the limit rather than hide it.
 **Consequence for the phases below:** because the `.so` contains coreasm,
 Phase 1's PIC work is **required**, not optional — `resource.asm`'s 34
 absolute `[abs table + reg*8]` relocations cannot be relocated in a shared
-object. Phase 0 stands as written for the include block, with the mangling
-`%define` prologue added.
+object. Phase 0 stands as written for the include block, with the
+symbol-visibility work added.
 
 ### Phase 0 — emit the runtime in shared mode (US-1)
 
 In the final-assembly step of `src/codegen/mod.rs` (the
-`if self.shared_lib_mode` branch at `:1342`), emit the **same
+`if self.shared_lib_mode` branch at `:2043`), emit the **same
 conditional include block** the executable path uses (core + the
 `uses_*`-gated modules), keeping `default rel` and keeping the existing
-no-`_start` text section (`:1400`). NASM labels are module-local unless
-declared `global`, so runtime symbols do not leak from the `.so` —
-only the `global <func>` exports do (`:1891`). `args.asm` must be
+no-`_start` text section (`:2113`, which emits `global` for each entry
+of `exported_functions`, populated at `:2678`). `args.asm` must be
 excluded: it reads the Linux loader's stack layout, which never exists
 in a library.
+
+**Restrict the exported symbol set (see Current Behavior 5).** Including
+coreasm puts all 54 of its `global` symbols into `.dynsym`. Do *not* fix
+this by editing `global` declarations in coreasm — that is 54 edits
+repeated for every architecture M6 adds. Pass an anonymous linker version
+script instead: `src/main.rs` writes a temp `.map` naming only the
+program's exported functions, and adds `--version-script=<map>` to the
+`-shared` `ld` invocation at `:418`. Verified end-to-end on the probe:
+
+```
+$ printf '{ global: vox_add; local: *; };\n' > vox.map
+$ ld -shared --version-script=vox.map -o probe.so probe.o
+$ nm -D --defined-only probe.so
+00000000000005c4 T vox_add
+```
+
+Use the **anonymous** form (no version tag). A named script such as
+`VOX_1 { ... }` also works but stamps exports as `vox_add@@VOX_1`, which
+complicates the `nm` assertion in Phase 2 for no benefit. The temp file
+should sit beside the `.o` and be cleaned up with it.
 
 Top-level executable statements in a `--shared` compile are currently
 generated into the discarded main body — i.e. silently dropped. Add an
@@ -225,8 +289,12 @@ programs (the bar set by `4fb5694`).
   that uses a buffer (exercises the Phase-1 `resource.asm` work).
 - New `test.sh` section:
   1. build the `.so`; assert exit 0;
-  2. `nm -D --defined-only` contains the three exports, **mangled**
-     (`libmath_1_0_add`, not `libmath_1.0_add`);
+  2. `nm -D --defined-only` lists the three exports **and nothing else**
+     — this is the assertion that holds Phase 0's version script honest,
+     so write it as an exact set comparison, not a `grep` for presence.
+     Export names at this phase are the plain function labels produced
+     by `mangle_symbol` (`add`, not `libmath_1_0_add`): `<lib>_<version>_`
+     prefixing arrives with Phase 3, and this assertion changes then;
   3. `readelf -d` shows a valid dynamic section;
   4. link a driver against it and call across the boundary, asserting
      both the return value and that the library's error accessor
@@ -249,7 +317,8 @@ Not planned in detail here; when picked up, it should get its own plan
 document. The seam left by Phases 0–2: `Statement::See` in the
 analyzer becomes the point that (a) reads a `.lib` file, (b) registers
 external function signatures into `self.functions` so the
-"Unknown function" check (`src/analyzer/mod.rs:1712`) passes, and
+"Unknown function" check (`src/analyzer/mod.rs:1789`, and the second
+site at `:2539`) passes, and
 (c) codegen emits `extern <symbol>` + the `--link` flags instead of a
 comment. Mangling and `.lib` generation live in the `--shared` compile;
 version enforcement lives in the `see` resolution. Design authority:
@@ -269,19 +338,20 @@ growth across the realloc boundary remain open.
 
 | File | Change | Phase |
 |------|--------|-------|
-| `src/codegen/mod.rs` | emit conditional coreasm includes in shared mode (minus `args.asm`) | 0 |
-| `src/codegen/mod.rs` | emit the mangling `%define` prologue ahead of the includes | 0 |
-| `src/analyzer/mod.rs` | error on top-level executable statements under `--shared` | 0 |
+| `src/codegen/mod.rs:2043` | emit conditional coreasm includes in shared mode (minus `args.asm`) | 0 |
+| `src/main.rs:418` | write an anonymous version script; pass `--version-script` to the `-shared` `ld` | 0 |
+| `src/analyzer/mod.rs:2293` | error on top-level executable statements under `--shared` | 0 |
 | `src/main.rs` | thread a `--shared` flag into the analyzer for that diagnostic | 0 |
 | `coreasm/x86_64/resource.asm` | 34 sites: `[abs T + r*s]` → `lea`+index, PIC-safe | 1 |
 | `src/codegen/mod.rs` | `.fini_array` entry for the library's `_cleanup_all`; make it idempotent | 1 |
 | `src/codegen/mod.rs` | emit explicit cleanup calls per linked library before `sys_exit` (a Vox host never reaches `_dl_fini`) | 1 |
 | `src/codegen/mod.rs` | fetch-and-merge the library's error value after each library call | 1 |
 | `src/main.rs:443` | `-dynamic-linker`/`-rpath` on executable links when `link_libs` non-empty | 2 |
-| `test.sh` | shared-library section (build, mangled exports, dynamic section, asm driver) | 2 |
+| `test.sh` | shared-library section (build, exact export set, dynamic section, asm driver) | 2 |
 | `tests/shared/libmath.vox`, `tests/runtime/*.asm` | new | 2 |
 | `LANGUAGE.md` | document what `--shared` supports and rejects | 0–2 |
 | `docs/plans/README.md` | register this plan | 0 |
+| `src/codegen/mod.rs` | capture `LibraryDecl` name/version onto the generator; emit the mangling `%define` prologue | 3 |
 
 Already in place: `mangle_symbol` in `src/codegen/mod.rs` with its
 collision guard in the analyzer, and the standard it implements in
@@ -290,8 +360,12 @@ without a guard because their alphabet (`[0-9.]`) cannot produce a
 collision; author-chosen components fold and are checked.
 
 Unchanged by design: `src/parser/mod.rs` (`see`/`Library` parsing is
-complete), `src/codegen/mod.rs:3199` (`See`/`LibraryDecl` stay comments
-until Phase 3).
+complete at `:3810`/`:3839`), `src/codegen/mod.rs:4119`/`:4125`
+(`LibraryDecl`/`See` stay comments until Phase 3).
+
+> Line numbers in this document were re-verified against `bb7584d` on
+> 2026-08-01. They drift; treat them as a starting point and confirm by
+> the surrounding code, not the number.
 
 ---
 
@@ -301,7 +375,11 @@ until Phase 3).
       arithmetic, print, and buffers — no NASM errors, no `ld`
       relocation errors.
 - [ ] `readelf -r` on the shared object path shows **zero**
-      `R_X86_64_32`/`R_X86_64_32S` relocations.
+      `R_X86_64_32`/`R_X86_64_32S` relocations (34 today, all from
+      `resource.asm`).
+- [ ] `nm -D --defined-only` on that `.so` lists **only** the library's
+      own exports — zero of the 54 coreasm `global` symbols reach
+      `.dynsym`.
 - [ ] All test and example programs still compile with **zero** NASM
       warnings (223 programs as of 2026-08-01; no regression of `4fb5694`).
 - [ ] `./test.sh` and `cargo test --release` stay green (192 integration
@@ -309,7 +387,8 @@ until Phase 3).
 - [ ] Hosted runtime behavior is byte-for-byte equivalent in observable
       output — `test.sh` is the arbiter.
 - [ ] A C or Rust program can load the `.so`, call an exported function
-      by its mangled name, and see its resources cleaned up at exit.
+      by the name `nm -D` reports for it, and see its resources cleaned
+      up at exit.
 
 ---
 
@@ -317,8 +396,10 @@ until Phase 3).
 
 1. **Given** a `.vox` file containing only function definitions,
    **when** compiled with `--shared`, **then** a `.so` is produced and
-   `nm -D --defined-only` lists exactly the defined functions — no
-   runtime symbols exported.
+   `nm -D --defined-only` lists exactly the defined functions and
+   nothing else — none of coreasm's 54 `global` runtime symbols appear.
+   Assert as a set equality; a presence-only `grep` passes while the
+   leak is wide open.
 2. **Given** a library function that prints and one that uses a buffer,
    **when** compiled with `--shared`, **then** the build succeeds
    (runtime included, PIC-clean) and the printing function works when
@@ -330,9 +411,12 @@ until Phase 3).
 4. **Given** the assembly driver, **when** it calls the arithmetic
    export with known operands, **then** the returned value is correct
    (proves calling convention survives the boundary).
-5. **Given** a machine without a C compiler, **when** `./test.sh` runs,
-   **then** the driver sub-test reports as skipped and the suite still
-   passes.
+5. **Given** a machine with only `nasm` and `ld` — the toolchain Vox
+   already requires — **when** `./test.sh` runs, **then** the driver
+   sub-test **executes and passes**. It must never report "skipped":
+   the driver is assembly precisely so that no host-toolchain check can
+   gate it, and a sub-test that skips silently would let CI go green
+   with the boundary untested.
 6. **Given** the full existing suite (`./test.sh`, `cargo test
    --release`, warning-free NASM check), **when** run after each phase,
    **then** all pass unchanged.
@@ -344,7 +428,9 @@ until Phase 3).
 **Phase 0**
 - [ ] Emit conditional coreasm includes in `shared_lib_mode` (exclude
       `args.asm`); keep `default rel`
-- [ ] Emit the mangling `%define` prologue ahead of the includes
+- [ ] Write an anonymous version script and pass `--version-script` to the
+      `-shared` `ld`, so none of coreasm's 54 `global` symbols reach
+      `.dynsym`; clean the temp `.map` up with the `.o`
 - [x] Inline `see` of a `.vox` file — done 2026-08-01, with
       `tests/208_source_include.vox`
 - [ ] Analyzer: reject top-level executable statements under `--shared`
@@ -370,10 +456,11 @@ until Phase 3).
 
 **Phase 2**
 - [ ] `tests/shared/libmath.vox` (arith + print + buffer functions)
-- [ ] `test.sh` shared section: build, mangled-export assert via `nm -D`,
-      `readelf -d` assert, and an **assembly** driver under
-      `tests/runtime/` (never C — it would add a toolchain the project
-      avoids and would skip silently when absent)
+- [ ] `test.sh` shared section: build, **exact export-set** assert via
+      `nm -D` (set equality, not `grep` presence), `readelf -d` assert,
+      and an **assembly** driver under `tests/runtime/` (never C — it
+      would add a toolchain the project avoids and would skip silently
+      when absent)
 - [ ] `-dynamic-linker`/`-rpath` on executable `ld` when `link_libs`
       non-empty
 - [ ] Regression tests ROADMAP M0 asks for: list growth across realloc
@@ -389,8 +476,16 @@ until Phase 3).
   `coreasm/` — worth a grep in the test harness or CI.
 - Each `.so` carrying its own runtime is now the **decided design**, not a
   limitation: it is what lets the library be loaded by a C or Rust host and
-  keep the exact runtime it was compiled against. Mangling makes it safe
-  even for two versions inside one `.so`.
+  keep the exact runtime it was compiled against. The version script keeps
+  that private runtime out of the dynamic namespace; mangling (Phase 3)
+  makes it safe even for two versions inside one `.so`. The two are
+  complementary — visibility controls what escapes the `.so`, mangling
+  controls what collides *within* one.
+- The version-script approach was chosen over adding `hidden` visibility
+  qualifiers to coreasm's `global` declarations for the same reason the
+  `%define` mangling was: it is zero coreasm edits, and coreasm gets
+  ported three more times in M6. Prefer link-time solutions to source
+  edits anywhere this trade-off recurs.
 - The cost is that per-version counters fail *permissive*.
   `_check_call_depth`'s 10 000 limit and `_print_depth`'s 64-deep cycle
   budget apply per module, so recursion or a cyclic structure crossing the


### PR DESCRIPTION
Validated `docs/plans/200_shared_library_repair.md` against `bb7584d` before handing it to an implementer. The core diagnosis held up — `readelf -r` confirms **exactly 34** `R_X86_64_32S` relocations against `.bss`, all from `resource.asm`, and a runtime-light `.so` does build end-to-end with only the Phase 0 include fix. But four things would have stalled or misled whoever picked it up.

Docs-only change.

## 1. Symbol visibility was missing entirely (blocker)

Phase 0 asserted that runtime symbols "do not leak from the `.so`" because NASM labels are module-local unless declared `global`. True as a rule — but **54 coreasm symbols carry an explicit `global`** (29 `resource.asm`, 12 `args.asm`, 9 across `string`/`int`/`float`). Every one lands in `.dynsym`. The probe exports nine runtime symbols for one exported function:

```
$ nm -D --defined-only probe.so
_mem_eq  _parse_i64  _parse_i64_bounded  _parse_int_radix
_parse_int_radix_bounded  _strdup_bounded  _str_eq  _str_len
_text_to_boolean  vox_add
```

Acceptance Criterion 1 was unachievable as written. Added as *Current Behavior 5* with evidence, and as a Phase 0 task using an anonymous linker version script — verified end-to-end, **zero coreasm edits**, which matters because M6 ports coreasm three more times.

Scoped honestly rather than overstated: intra-library calls bound directly in the probe (zero `JUMP_SLOT` relocations), so the defect is the exported namespace, not the internal call path.

## 2. Acceptance Criterion 5 contradicted Phase 2

AC 5 required the driver sub-test to skip when no C compiler is present — a leftover from the draft Phase 2 explicitly rejects. Inverted: the driver is assembly precisely so no toolchain check can gate it, and a silently skipping sub-test would let CI report green with the boundary untested.

## 3. Export names were specified three different ways

Phase 2 said `libmath_1_0_add`; the out-of-scope list deferred `<lib>_<version>_<func>` to Phase 3; AC 1 said plain function names. Settled on plain `mangle_symbol` labels for Phase 2, with prefixing arriving in Phase 3 and the assertion changing then. Both sites now require **set equality** on `nm -D` output — a presence-only `grep` passes while the leak is wide open, which is how this would rot.

## 4. The `%define` prologue had no specified input

`LibraryDecl`'s name and version are consumed inline in the statement walk and never stored on the generator, and behaviour with no `Library` declaration was undefined.

Re-sequenced mangling from Phase 0 to Phase 3. **The architecture decision is unchanged — only its build order moves.** Its precondition is two library versions inside one `.so`, which requires the `.lib` metadata already deferred to Phase 3; Phases 0–2 compile one library per `.so`, where the version script solves the collision problem more completely by removing the symbols from `.dynsym` rather than making them uniquely named but still exported. `mangle_symbol` and `SYMBOL_MANGLING.md` are untouched.

## Also

Line numbers re-verified against `bb7584d` — most had drifted 700–900 lines (`:1342` → 2043, `:1891` → 2678, `:3199` → 4119). Added a note that they drift and surrounding code is the real anchor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)