### PR TITLE
Fix seven findings from the shared-library review (plan 210)

### DIFF
--- a/docs/plans/200_shared_library_repair.md
+++ b/docs/plans/200_shared_library_repair.md
@@ -538,10 +538,22 @@ Three things are carried forward rather than finished:
 2. **Growable resource tables** were folded into Phase 1 to avoid touching
    the same 34 sites twice. Those sites are now rewritten, so that saving is
    gone and the work needs its own plan.
-3. **The C/Rust host path is unverified.** The assembly driver proves the
-   SysV boundary, not the `_dl_fini` cleanup a libc host relies on. That
-   wants a one-off manual check rather than a harness test, since the suite
-   deliberately cannot depend on a C toolchain.
+3. **The `.fini_array` / `_cleanup_all` path is unverified, and the
+   C/Rust host path is the same gap.** Phase 1 registers `_cleanup_all` in
+   `.fini_array` so a libc host runs cleanup on unload, but nothing in the
+   suite reaches it: `tests/runtime/shared_lib_driver.asm` exits through a
+   raw `sys_exit`, which never calls `_dl_fini`, which is what would run
+   `.fini_array`. The code is therefore untested by construction — the
+   suite would stay green if it were deleted. The assembly driver proves
+   the SysV boundary and the PIC runtime; it does **not** prove the
+   `_dl_fini` cleanup a libc host relies on. What would verify it is a
+   one-off manual check with a C or Rust host (load the `.so`, call an
+   export, exit normally, confirm cleanup ran) — the same check the
+   unticked success criterion below names. The two are one gap, not two:
+   the suite deliberately cannot depend on a C toolchain (`nasm` + `ld` +
+   `cargo` only), and a `command -v cc` guard would skip silently and let
+   CI go green with nothing tested, so this is recorded here rather than
+   papered over with a host the harness cannot honestly run.
 
 Also worth recording: `LANGUAGE.md` still contains a pre-existing
 contradiction, where the `see` section lists `see "./lib.so"` as working

--- a/docs/plans/210_shared_library_review_fixes.md
+++ b/docs/plans/210_shared_library_review_fixes.md
@@ -1,0 +1,176 @@
+# Plan 210 — shared-library review fixes
+
+Findings from a full read of the Phases 0–2 implementation (plan 200,
+commits `238f5df`..`a310237`, merged as PR #101). The feature works and its
+suite is green; these are defects and gaps the suite does not catch.
+
+Each finding below was reproduced before being written down. Reproduce it
+yourself before fixing it, and confirm your fix turns that reproduction
+around — a fix you cannot demonstrate is a fix you cannot trust.
+
+---
+
+## P1 — `--shared` destroys a user's pre-existing `.map` file
+
+**Severity: data loss.** This is the only finding that damages something the
+user owns.
+
+`src/main.rs:428` writes the linker version script to `<base_name>.map`,
+derived from the *source* filename, in the user's working directory. If a
+file of that name already exists it is overwritten, and `:509` then deletes
+it. Reproduced:
+
+```
+$ printf 'MY IMPORTANT LINKER SCRIPT\n' > victim.map
+$ vox victim.vox --shared -o victim.so
+$ ls victim.map
+ls: cannot access 'victim.map': No such file or directory
+```
+
+A `.map` next to a source file is entirely plausible — linker scripts and
+source maps both use that extension.
+
+**Fix.** The version script is a pure implementation detail with no value to
+the user, so it should never touch their directory. Write it to a uniquely
+named temp file (`std::env::temp_dir()` plus the process id, or an existing
+temp-file helper) and delete that. Keep the existing property that it is
+removed on both the success and failure paths.
+
+Note `.asm` and `.o` use the same `base_name` pattern, but those are the
+compiler's own declared outputs and predate this work — leave them alone.
+
+**Test.** A cargo test that creates `<name>.map`, compiles `<name>.vox
+--shared`, and asserts the file still exists with its original contents.
+
+---
+
+## P2 — the shared test corpus never exercises `mangle_symbol`
+
+`tests/shared/libmath.vox` exports `add_two`, `greet`, `makebuf` — all three
+already valid C identifiers, so `mangle_symbol` is an identity function on
+them. The `test.sh` export-set assertion is exact and good, but it cannot
+catch a mangling regression, and mangling is what produces every export name.
+
+The feature itself is fine — verified separately:
+
+```
+To "add two numbers" with a number called "n".
+  Return n add 2.
+```
+```
+$ nm -D --defined-only mangle_lib.so
+00000000000003d5 T add_two_numbers
+```
+
+**Fix.** Rename at least one export in `tests/shared/libmath.vox` to a
+natural multi-word Vox name so the label is *produced* by mangling rather
+than coinciding with it — e.g. `To "add two"` exporting `add_two`. Update the
+expected set in `test.sh` and the `extern` in the driver to match. Prefer
+renaming an existing function to adding a fourth; the corpus should stay
+small.
+
+This also makes the corpus read like Vox. `To "makebuf"` is C-style naming in
+an English-like language.
+
+---
+
+## P3 — the two new diagnostics have no source location
+
+Every other compiler error carries file, line, column and a source excerpt.
+The two `--shared` diagnostics do not, because both call `push_error(..., None)`
+(`src/analyzer/mod.rs`). Side by side:
+
+```
+error: Top-level print statement is not allowed in a shared library: ...
+```
+```
+error: Unknown variable: nosuchvar
+  --> err.vox:1:16
+   |
+ 1 | To "g". Return nosuchvar.
+```
+
+**Fix.** Pass the offending statement's span so both diagnostics point at the
+line. If `Statement` does not currently carry a usable span for this, say so
+in your report rather than inventing one — that would be a real finding about
+the AST and worth its own work.
+
+Keep the existing "stop at the first offender" behaviour; that is deliberate
+and correctly avoids a cascade.
+
+---
+
+## P4 — `.fini_array` / `_cleanup_all` is registered but never exercised
+
+Phase 1 registers `_cleanup_all` in `.fini_array` so a libc host cleans up on
+unload. Nothing in the suite reaches it: `tests/runtime/shared_lib_driver.asm`
+exits through a raw `sys_exit`, which never reaches `_dl_fini`, which is what
+would run `.fini_array`. So the code is untested by construction, and the
+suite would stay green if it were deleted.
+
+**Do not fix by adding a C host** — the project deliberately depends only on
+`nasm`, `ld` and `cargo`, and a `command -v cc` guard would skip silently.
+
+**Fix.** Record the gap honestly rather than paper over it: a short note in
+plan 200's status section stating that the `.fini_array` path is unverified,
+what would verify it (a libc host, checked manually and recorded), and why
+the suite cannot. Plan 200 already carries an unticked success criterion for
+the C/Rust host — make these two consistent so a reader is not left thinking
+one covers the other.
+
+---
+
+## P5 — a driver failure cannot be diagnosed
+
+All three assertions in `shared_lib_driver.asm` jump to a single `.fail` that
+exits 1. When CI reports `shared/libmath (driver exited 1)`, nothing indicates
+whether arithmetic, the buffer, or the boundary itself broke.
+
+**Fix.** Give each assertion a distinct non-zero exit code (e.g. 2 = add_two,
+3 = makebuf) and have `test.sh` map the code back to a named check in its
+failure message. Keep it terse — this is coreasm-adjacent test code and gets
+read more than it gets run.
+
+---
+
+## P6 — the dynamic loader path is hard-coded for x86-64
+
+`src/main.rs` emits `-dynamic-linker /lib64/ld-linux-x86-64.so.2`
+unconditionally, while codegen already carries `self.target_arch` and M6 adds
+three more architectures.
+
+**Fix.** This does not need solving now and should not be over-built. Add a
+comment at the site naming it as an x86-64 assumption that M6 must revisit, so
+the next person porting finds it by reading rather than by debugging. If a
+target-arch value is already threaded to that point, deriving the path from it
+is fine; do not plumb one through just for this.
+
+---
+
+## P7 — the `.map` path is computed in two places
+
+`src/main.rs:428` builds `map_path`, and `:509` independently recomputes
+`format!("{}.map", base_name)` to delete it. Change one and the other leaks a
+file. P1's fix should collapse this to a single value; if it does not, hoist
+it so the path exists once.
+
+---
+
+## Out of scope
+
+Do not start plan 200 Phase 3, do not touch the `LANGUAGE.md` `see "./lib.so"`
+contradiction (it resolves in Phase 3), and do not begin growable resource
+tables. Those are all separately tracked.
+
+## Success criteria
+
+- [ ] P1 reproduction fails to reproduce; a cargo test guards it
+- [ ] At least one export in the shared corpus is produced by mangling
+- [ ] Both `--shared` diagnostics carry file/line/column, or the report
+      explains precisely why they cannot
+- [ ] Plan 200's `.fini_array` and C/Rust-host gaps read consistently
+- [ ] Driver failures name the failing check
+- [ ] `cargo build --release` 0 warnings; `cargo test --release` ≥ 115;
+      `./test.sh` ≥ 196 passed, 0 failed, **skips still 6**
+- [ ] On a built `.so`: `readelf -r` 0 absolute relocations, `nm -D` exactly
+      the corpus exports

--- a/docs/plans/210_shared_library_review_fixes.md
+++ b/docs/plans/210_shared_library_review_fixes.md
@@ -162,6 +162,32 @@ Do not start plan 200 Phase 3, do not touch the `LANGUAGE.md` `see "./lib.so"`
 contradiction (it resolves in Phase 3), and do not begin growable resource
 tables. Those are all separately tracked.
 
+## Found while fixing these — not a code defect
+
+**A stale system install makes `--shared` look broken outside the repo.**
+Surfaced by the worker as a "coreasm path-resolution quirk"; the real cause is
+simpler and worth recording so nobody debugs the compiler over it.
+
+`find_coreasm_path` falls back to system paths when it is not run from a repo
+checkout. If `/usr/local/share/vox/coreasm` predates the Phase 1 PIC rewrite,
+a `--shared` build outside the repo assembles the *old* runtime and fails with
+exactly the 34 relocations Phase 1 removed. Demonstrated on one source file:
+
+```
+$ vox lib.vox --shared -o lib.so                     # system coreasm
+/usr/bin/ld.bfd: relocation R_X86_64_32S ... Linking failed
+
+$ EC_CORE_PATH=<repo>/coreasm vox lib.vox --shared -o lib.so
+$ nm -D --defined-only lib.so   → add_two
+```
+
+The fix is `sudo make install`, not a code change. What is arguably a defect is
+the *diagnostic*: the user sees a linker relocation error, with nothing
+connecting it to an out-of-date runtime. Version-stamping `coreasm` and warning
+on a mismatch between the compiler and the runtime it resolved would turn a
+confusing failure into a clear one. That wants its own plan — it affects every
+build path, not just `--shared`.
+
 ## Success criteria
 
 - [ ] P1 reproduction fails to reproduce; a cargo test guards it

--- a/src/analyzer/mod.rs
+++ b/src/analyzer/mod.rs
@@ -684,6 +684,17 @@ impl Analyzer {
                              definitions, 'Library', and 'see' may appear at the top level.",
                             shared_top_level_label(stmt)
                         ),
+                        // No source location: `Statement` carries no span (see
+                        // plan 210 P3). The only location mechanism here is
+                        // `find_symbol_location`, a text search keyed on a
+                        // symbol name; a top-level print/if/while/exit has no
+                        // name, and even the name-bearing kinds (assignment,
+                        // call) would resolve to the first textual occurrence
+                        // of that name anywhere in the file — usually inside a
+                        // function body, i.e. a misleading line. A real fix
+                        // needs spans threaded into the Statement AST (the
+                        // parser has token positions but discards them), which
+                        // is separate work.
                         None,
                     );
                     return;
@@ -708,6 +719,12 @@ impl Analyzer {
                      file defines none. Add a function definition, or drop --shared \
                      to build an executable."
                         .to_string(),
+                    // No source location: this reports an ABSENCE of function
+                    // definitions, so there is no offending statement and no
+                    // symbol to anchor `find_symbol_location` on (plan 210 P3).
+                    // Spanning the Statement AST would let this point at the
+                    // file/first line; until then it stays a message-only
+                    // diagnostic, deliberately.
                     None,
                 );
                 return;

--- a/src/main.rs
+++ b/src/main.rs
@@ -490,6 +490,13 @@ fn main() {
         // static binary with no loader dependency.
         let mut dynamic_args: Vec<String> = Vec::new();
         if !link_libs.is_empty() {
+            // FIXME(x86-64, M6): this loader path is hard-coded for x86-64.
+            // `target_arch` is in scope here (it is threaded down from the
+            // --arch flag / TARGET_ARCH at line ~249), so M6's port can derive
+            // the path from it per architecture instead of fixing this string
+            // by hand. Left as-is for now because the other architectures do
+            // not exist yet and guessing their loader paths would be worse
+            // than a grep-findable marker. See plan 210 P6.
             dynamic_args.push("-dynamic-linker".to_string());
             dynamic_args.push("/lib64/ld-linux-x86-64.so.2".to_string());
             for p in lib_paths.iter() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -416,6 +416,20 @@ fn main() {
         println!("Linking...");
     }
     
+    // The version script is a pure implementation detail the user never asked
+    // to see, so it must never touch their working directory — a `.map` next to
+    // a source file is entirely plausible (linker scripts and source maps both
+    // use that extension), and writing then deleting `<base_name>.map` there
+    // would destroy a pre-existing file (plan 210 P1). Put it in the system temp
+    // dir under a name unique to this process. The single `map_path` is the
+    // only place this path exists, so the cleanup below cannot drift from the
+    // write (plan 210 P7 — the two used to be recomputed independently).
+    let map_path = if build_shared {
+        Some(env::temp_dir().join(format!("vox-{}-{}.map", base_name, std::process::id())))
+    } else {
+        None
+    };
+
     let ld_result = if build_shared {
         // An anonymous version script restricts the dynamic symbol table to
         // exactly the library's exported functions. coreasm declares ~54 of
@@ -425,7 +439,7 @@ fn main() {
         // coreasm edits) for the same reason the %define mangling is: coreasm
         // is ported per architecture. The anonymous form (no version tag)
         // keeps `nm -D` reporting the plain symbol names.
-        let map_path = format!("{}.map", base_name);
+        let map_path = map_path.as_ref().unwrap();
         let mut script = String::from("{ global:");
         for func in codegen.exported_functions() {
             script.push_str(&format!(" {};", func));
@@ -438,7 +452,7 @@ fn main() {
 
         let mut all_args: Vec<String> = vec![
             "-shared".to_string(),
-            format!("--version-script={}", map_path),
+            format!("--version-script={}", map_path.display()),
             "-o".to_string(),
             output_path.clone(),
             obj_path.clone(),
@@ -504,9 +518,10 @@ fn main() {
     // cleanup used to live after the success check, so a failed link left
     // `<name>.map` in the user's working directory — a file they never asked
     // to see, named for a script they have no reason to know exists. Removing
-    // it here covers both the success and the two failure exits below.
-    if build_shared {
-        let _ = fs::remove_file(format!("{}.map", base_name));
+    // it here covers both the success and the two failure exits below. The
+    // temp path lives in `map_path`, the same value written above.
+    if let Some(ref p) = map_path {
+        let _ = fs::remove_file(p);
     }
 
     match ld_result {

--- a/test.sh
+++ b/test.sh
@@ -256,9 +256,9 @@ run_shared_library_test() {
     else
         local got exp
         got=$(nm -D --defined-only "$work/libmath.so" | awk '{print $3}' | sort)
-        exp=$(printf '%s\n' add_two greet makebuf | sort)
+        exp=$(printf '%s\n' add_two_numbers greet makebuf | sort)
         if [[ "$got" != "$exp" ]]; then
-            fail_msg="shared/libmath (export set is not exactly {add_two, greet, makebuf})"
+            fail_msg="shared/libmath (export set is not exactly {add_two_numbers, greet, makebuf})"
             { echo "expected:"; echo "$exp" | sed 's/^/  /'; echo "got:"; echo "$got" | sed 's/^/  /'; } >"$work/diff.log"
             fail_log="$work/diff.log"
         # 3. readelf -d reports a parseable dynamic section.
@@ -276,7 +276,12 @@ run_shared_library_test() {
             out=$("$work/driver" 2>"$work/run.err")
             rc=$?
             if [[ $rc -ne 0 ]]; then
-                fail_msg="shared/libmath (driver exited $rc)"; fail_log="$work/run.err"
+                case "$rc" in
+                    2) fail_msg="shared/libmath (driver: add_two_numbers(40) != 42)" ;;
+                    3) fail_msg="shared/libmath (driver: makebuf() != 5)" ;;
+                    *) fail_msg="shared/libmath (driver exited $rc)" ;;
+                esac
+                fail_log="$work/run.err"
             elif [[ "$out" != "hello from libmath" ]]; then
                 fail_msg="shared/libmath (driver stdout mismatch)"
                 { echo "expected: hello from libmath"; echo "got: $out"; } >"$work/out.log"

--- a/tests/p210_map_preservation.rs
+++ b/tests/p210_map_preservation.rs
@@ -1,0 +1,64 @@
+// Plan 210 P1 — `--shared` must not destroy a pre-existing `<source>.map`.
+//
+// The version script the linker needs is a pure implementation detail with no
+// value to the user, so it must never land in their working directory: a `.map`
+// next to a source file is plausible (linker scripts and source maps both use
+// the extension), and the old code wrote `<base_name>.map` there and then
+// deleted it — destroying whatever the user had. This drives the real
+// compiler binary on a real `--shared` compile and asserts a pre-existing
+// `<name>.map` survives with its original contents.
+//
+// It invokes the built `vox` binary, which shells out to nasm + ld, so it
+// shares the toolchain the rest of the suite already requires (test.sh builds
+// every program the same way). It never skips — a missing toolchain fails the
+// build loudly, the way the project wants.
+
+use std::fs;
+use std::process::{Command, Stdio};
+
+#[test]
+fn shared_does_not_clobber_preexisting_map() {
+    let work = std::env::temp_dir().join(format!("vox-p210-map-{}", std::process::id()));
+    let _ = fs::remove_dir_all(&work);
+    fs::create_dir_all(&work).expect("create temp work dir");
+
+    // A precious, user-owned linker script beside the source.
+    let precious = "MY IMPORTANT LINKER SCRIPT\n";
+    fs::write(work.join("victim.map"), precious).expect("write victim.map");
+
+    // A one-export library — the smallest thing `--shared` accepts.
+    fs::write(
+        work.join("victim.vox"),
+        "To \"greet\".\n  Print \"hi\".\n",
+    )
+    .expect("write victim.vox");
+
+    let vox = env!("CARGO_BIN_EXE_vox");
+    let output = Command::new(vox)
+        .arg(work.join("victim.vox"))
+        .arg("--shared")
+        .arg("-o")
+        .arg(work.join("victim.so"))
+        .current_dir(&work)
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .output()
+        .expect("spawn vox");
+
+    assert!(
+        output.status.success(),
+        "vox --shared failed; stderr:\n{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    // The user's file must still exist, untouched.
+    let after = fs::read_to_string(work.join("victim.map"))
+        .expect("victim.map must still exist after --shared");
+    assert_eq!(
+        after, precious,
+        "victim.map was overwritten or deleted by the --shared compile"
+    );
+
+    let _ = fs::remove_dir_all(&work);
+}

--- a/tests/runtime/shared_lib_driver.asm
+++ b/tests/runtime/shared_lib_driver.asm
@@ -5,15 +5,18 @@
 ; PLT, proving the Vox calling convention survives the .so boundary and that
 ; the library's own coreasm runtime works when driven from a foreign host:
 ;
-;   add_two(40) -> 42        arithmetic; one scalar arg in rdi, result in rax
-;   makebuf()    -> 5        buffer registration via resource.asm (Phase 1 PIC
-;                            tables) — the case that could not relocate before
-;                            the lea [rel] rewrite
-;   greet()      prints      "hello from libmath" (io/format includes)
+;   add_two_numbers(40) -> 42  arithmetic; one scalar arg in rdi, result in rax
+;   makebuf()    -> 5          buffer registration via resource.asm (Phase 1 PIC
+;                              tables) — the case that could not relocate before
+;                              the lea [rel] rewrite
+;   greet()      prints        "hello from libmath" (io/format includes)
 ;
 ; The library carries its own runtime; the driver references only the three
 ; exported labels (the version script keeps every coreasm symbol local, so
-; nothing else is even visible to link against). Exit 0 = pass, 1 = fail.
+; nothing else is even visible to link against). Exit 0 = pass; a non-zero
+; exit names the failing check — 2 = add_two_numbers, 3 = makebuf — so test.sh
+; can report which assertion broke instead of a bare "exited 1". greet has no
+; exit code: the harness checks its stdout, not a return value.
 ;
 ; nasm + ld only — no C, no libc — so this always runs and can never silently
 ; skip the way a `command -v cc` guarded dlopen driver would. Follows the
@@ -21,7 +24,7 @@
 
 global _start
 
-extern add_two
+extern add_two_numbers
 extern greet
 extern makebuf
 
@@ -32,12 +35,13 @@ _start:
     ; Vox prologue (push rbp) assumes the caller honoured it.
     and rsp, -16
 
-    ; add_two(40) == 42 — proves a scalar arg crosses the boundary and the
-    ; result returns in rax.
+    ; add_two_numbers(40) == 42 — proves a scalar arg crosses the boundary and
+    ; the result returns in rax. The label is mangled from "add two numbers",
+    ; so this also proves mangle_symbol survived the .so boundary.
     mov rdi, 40
-    call add_two
+    call add_two_numbers
     cmp rax, 42
-    jne .fail
+    jne .fail_add
 
     ; makebuf() == 5 — creates a buffer inside the library, registering it in
     ; buf_table. This is the resource.asm access that was 34 absolute
@@ -45,7 +49,7 @@ _start:
     ; traps here.
     call makebuf
     cmp rax, 5
-    jne .fail
+    jne .fail_makebuf
 
     ; greet() prints the line; the harness compares the driver's stdout.
     call greet
@@ -55,7 +59,11 @@ _start:
     xor rdi, rdi
     syscall
 
-.fail:
+.fail_add:
     mov rax, 60
-    mov rdi, 1
+    mov rdi, 2
+    syscall
+.fail_makebuf:
+    mov rax, 60
+    mov rdi, 3
     syscall

--- a/tests/shared/libmath.vox
+++ b/tests/shared/libmath.vox
@@ -3,9 +3,14 @@ real library needs: pure arithmetic, printing, and buffer use. The buffer
 function is the one that exercises the Phase 1 resource.asm PIC work —
 buffer registration touches buf_table, the table that could not be relocated
 before the lea [rel] rewrite. Built with `vox --shared`; called from
-tests/runtime/shared_lib_driver.asm.)
+tests/runtime/shared_lib_driver.asm.
 
-To "add_two" with a number called "n".
+The arithmetic export is named with a space on purpose: "add two numbers"
+mangles to the label `add_two_numbers`, so the export-set assertion in
+test.sh exercises mangle_symbol instead of passing on an identity. See
+plan 210 P2.)
+
+To "add two numbers" with a number called "n".
   Return n add 2.
 
 To "greet".


### PR DESCRIPTION
A full read of the plan 200 Phases 0–2 implementation, covering the files the first review pass skipped: the analyzer diagnostics, both `main.rs` link paths, the shared test corpus, and the driver assembly. Seven findings, each reproduced before being written down and each fix demonstrated by turning that reproduction around.

Spec: `docs/plans/210_shared_library_review_fixes.md` (added in `f2fbafc`).

## P1 — `--shared` destroyed a user's pre-existing `.map` file

The only finding that damaged something the user owns. The linker version script was written to `<source>.map` in the working directory and then deleted, so:

```
$ printf 'MY IMPORTANT LINKER SCRIPT\n' > victim.map
$ vox victim.vox --shared -o victim.so
$ ls victim.map
ls: cannot access 'victim.map': No such file or directory
```

A `.map` beside a source file is entirely plausible — linker scripts and source maps both use that extension. Fixed by writing to `env::temp_dir()` under a name unique to the process; the script is a pure implementation detail and should never have touched the user's directory. Guarded by a new cargo test. This also collapsed **P7** (the path was computed in two places) to a single value.

## P2 — the export-set assertion could not catch a mangling regression

The corpus exported `add_two`, `greet`, `makebuf` — all already valid C identifiers, so `mangle_symbol` was an identity function on them and the exact-set check in `test.sh` proved nothing about the transform that produces every export name. The corpus now declares `To "add two numbers"`, so the exported `add_two_numbers` is *produced* by mangling rather than coinciding with it.

## P5 — driver failures were undiagnosable

All three assertions exited 1, so CI could only say `driver exited 1`. Distinct exit codes (2 = `add_two_numbers`, 3 = `makebuf`) now map to named checks in the harness message.

## P3, P4, P6 — recorded rather than papered over

**P3** (the two `--shared` diagnostics carry no file/line/column, unlike every other compiler error) took the plan's explicit escape hatch. `Statement` carries no span, and the analyzer's only location mechanism is `find_symbol_location`, a text search keyed on a symbol name — so a top-level `print`/`if` has nothing to search for, and a name-bearing statement would resolve to the first textual occurrence anywhere in the file, i.e. a confidently wrong line. **Verified independently during review**: no `Statement` variant carries positional data. A real fix needs spans threaded through the parser, which has token positions and discards them. Documented at both sites.

**P4** — `.fini_array`/`_cleanup_all` is registered but unreachable from the suite: the driver exits via raw `sys_exit`, which never reaches `_dl_fini`. Untested by construction. Recorded in plan 200's status section and tied to its existing unticked C/Rust-host criterion so a reader sees one gap rather than two. Not "fixed" with a C host — that would add a toolchain the project deliberately avoids and would skip silently.

**P6** — `FIXME(x86-64, M6)` at the hard-coded loader path. `target_arch` is in scope there for the port; deriving it now would mean guessing loader paths for architectures that do not exist yet.

## Also recorded: a stale install makes `--shared` look broken

Surfaced by the worker as a path-resolution quirk; the cause is simpler. `find_coreasm_path` falls back to system paths outside a repo checkout, and a `/usr/local/share/vox/coreasm` predating Phase 1 assembles the old runtime — failing with exactly the 34 relocations Phase 1 removed. Same file, both ways:

```
$ vox lib.vox --shared -o lib.so                      → R_X86_64_32S, Linking failed
$ EC_CORE_PATH=<repo>/coreasm vox lib.vox --shared    → exit 0, exports add_two
```

The fix is `sudo make install`, not code. The arguable defect is the *diagnostic* — nothing ties a linker relocation error to an out-of-date runtime. Version-stamping `coreasm` would fix that, but it affects every build path, so it wants its own plan.

## Verification

| | |
|---|---|
| build | 0 warnings |
| `cargo test --release` | **116** (was 115; +1 guarding P1) |
| `./test.sh` | **196** passed, 0 failed, **6 skipped** (baseline held) |
| `readelf -r` on the `.so` | 0 `R_X86_64_32` |
| `nm -D --defined-only` | exactly the corpus exports |

Verified from an isolated `git archive` extract, not the working tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)