### PR TITLE
Track the compiler version in the VS Code extension

### DIFF
--- a/vox-vscode/README.md
+++ b/vox-vscode/README.md
@@ -96,9 +96,9 @@ cd vox-vscode
 vsce package
 
 # Install the generated .vsix file
-code --install-extension vox-0.1.72.vsix
+code --install-extension vox-0.2.0.vsix
 # Or for Windsurf:
-windsurf --install-extension vox-0.1.72.vsix
+windsurf --install-extension vox-0.2.0.vsix
 ```
 
 ---

--- a/vox-vscode/package.json
+++ b/vox-vscode/package.json
@@ -2,7 +2,7 @@
   "name": "vox",
   "displayName": "Vox syntax highlighting",
   "description": "Syntax highlighting for Vox (sentence based code) (.vox files)",
-  "version": "0.1.72",
+  "version": "0.2.0",
   "publisher": "vox-lang",
   "engines": {
     "vscode": "^1.75.0"


### PR DESCRIPTION
The extension published for the 0.2.0 release is versioned `0.2.0`, but the
repo said `0.1.72` — so rebuilding from source produced an artifact that did
not match the published one.

The extension ships the language's syntax and has no independent release
cadence, so it now tracks the compiler version. Someone seeing `vox 0.2.0` and
`vox-vscode 0.2.0` can reasonably assume the highlighting matches the compiler
they are running — the property the grammar drift checker already enforces
mechanically.

One line in `package.json`, plus the README's manual-install examples.

🤖 Generated with [Claude Code](https://claude.com/claude-code)