### PR TITLE
Pin the "callable from C" promise with a test

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -320,6 +320,78 @@ run_shared_library_test() {
 }
 run_shared_library_test
 
+# C-interop boundary test. LANGUAGE.md promises a .so is "callable from Vox —
+# or from C" and "loadable from C, Rust, or any other host"; SYMBOL_MANGLING.md
+# promises a standalone .so "must be callable from C". Nothing in the suite
+# checked any of that until now. Builds tests/cinterop/{mathkit,strkit}.vox
+# (two libraries, one .so — the same multi-input path as tests/shared) with
+# one numeric export and one text export, compiles tests/cinterop/driver.c
+# against it with gcc, and runs the result. Asserts: the .so has zero NEEDED
+# entries (freestanding — no libc pulled in on the Vox side, so it links into
+# a C program without conflict); both mangled exports (math_kit_1_0_add_two,
+# strkit_1_0_greet) are present in .dynsym; the C build produces zero
+# warnings; and the driver's exact stdout, not just its exit status. gcc is a
+# required part of this project's toolchain (already needed to build/test
+# elsewhere) and is present on every host that can run this suite — if it is
+# ever missing this FAILS loudly rather than skipping, because a silent skip
+# here would drop the only coverage of a promise the docs make three times.
+run_c_interop_test() {
+    local work fail_msg="" fail_log=""
+    work="$(mktemp -d)"
+
+    if ! command -v gcc >/dev/null 2>&1; then
+        fail_msg="c-interop (gcc not found - required toolchain, not optional)"
+    # 1. Build the .so from two libraries: one numeric export, one text export.
+    elif ! "$VOX_BIN" "$SCRIPT_DIR/tests/cinterop/mathkit.vox" "$SCRIPT_DIR/tests/cinterop/strkit.vox" \
+            --shared -o "$work/libcinterop.so" >"$work/build.log" 2>&1; then
+        fail_msg="c-interop (library build)"; fail_log="$work/build.log"
+    # 2. No NEEDED entries: the .so must be freestanding, pulling in no libc
+    #    of its own, so it links into a C program without conflict.
+    elif readelf -d "$work/libcinterop.so" 2>"$work/needed.log" | grep -q NEEDED; then
+        fail_msg="c-interop (.so has NEEDED entries - not freestanding)"
+        readelf -d "$work/libcinterop.so" >"$work/needed.log" 2>&1
+        fail_log="$work/needed.log"
+    else
+        # 3. Both mangled exports present in .dynsym.
+        local dynsyms
+        dynsyms=$(nm -D --defined-only "$work/libcinterop.so" | awk '{print $3}')
+        if ! grep -qx "math_kit_1_0_add_two" <<<"$dynsyms" || ! grep -qx "strkit_1_0_greet" <<<"$dynsyms"; then
+            fail_msg="c-interop (mangled exports missing from .dynsym)"
+            { echo "expected: math_kit_1_0_add_two, strkit_1_0_greet"; echo "got:"; echo "$dynsyms"; } >"$work/dynsym.log"
+            fail_log="$work/dynsym.log"
+        # 4. Compile the C driver against the .so with gcc. -Werror turns any
+        #    warning into a build failure, so "zero build warnings" is enforced
+        #    by the exit code, not a separate log scrape.
+        elif ! gcc -Wall -Wextra -Werror -std=c11 "$SCRIPT_DIR/tests/cinterop/driver.c" \
+                -L"$work" -l:libcinterop.so -Wl,-rpath,"$work" -o "$work/cmain" >"$work/gcc.log" 2>&1; then
+            fail_msg="c-interop (gcc build)"; fail_log="$work/gcc.log"
+        else
+            # 5. Run it; assert the exact expected output, not just exit status.
+            local out rc
+            out=$("$work/cmain" 2>"$work/run.err")
+            rc=$?
+            if [[ $rc -ne 0 ]]; then
+                fail_msg="c-interop (driver exited $rc)"; fail_log="$work/run.err"
+            elif [[ "$out" != "42 hello from vox" ]]; then
+                fail_msg="c-interop (driver stdout mismatch)"
+                { echo "expected: 42 hello from vox"; echo "got: $out"; } >"$work/out.log"
+                fail_log="$work/out.log"
+            fi
+        fi
+    fi
+
+    if [[ -n "$fail_msg" ]]; then
+        echo -e "  ${RED}FAIL${NC} $fail_msg"
+        [ -s "$fail_log" ] && sed 's/^/      /' "$fail_log" | head -30
+        ((FAILED++))
+    else
+        echo -e "  ${GREEN}PASS${NC} c-interop (gcc-linked .so: add_two(40)=42, greet()='hello from vox', no NEEDED)"
+        ((PASSED++))
+    fi
+    rm -rf "$work"
+}
+run_c_interop_test
+
 # Two-version shared-library boundary test (plan 230 stage A2). This is the
 # backwards-compatibility case the entire multi-version design exists for: TWO
 # VERSIONS of one library (flags 0.1 and flags 1.0) in ONE .so, both defining

--- a/tests/cinterop/driver.c
+++ b/tests/cinterop/driver.c
@@ -1,0 +1,27 @@
+/* C-interop boundary test driver. Linked against the .so that test.sh's
+ * run_c_interop_test builds from mathkit.vox + strkit.vox. Exercises both
+ * directions of the "callable from C" promise: a plain integer call (System
+ * V AMD64: arg in rdi, result in rax) and a text return read as a
+ * NUL-terminated char*, with no marshalling on either side. */
+#include <stdio.h>
+#include <string.h>
+
+extern long math_kit_1_0_add_two(long x);
+extern void *strkit_1_0_greet(void);
+
+int main(void) {
+    long n = math_kit_1_0_add_two(40);
+    if (n != 42) {
+        fprintf(stderr, "add_two(40) = %ld, want 42\n", n);
+        return 1;
+    }
+
+    const char *s = (const char *)strkit_1_0_greet();
+    if (strcmp(s, "hello from vox") != 0) {
+        fprintf(stderr, "greet() = %s, want 'hello from vox'\n", s);
+        return 2;
+    }
+
+    printf("%ld %s\n", n, s);
+    return 0;
+}

--- a/tests/cinterop/mathkit.vox
+++ b/tests/cinterop/mathkit.vox
@@ -1,0 +1,11 @@
+(C-interop boundary test fixture. Paired with strkit.vox in one --shared
+build (test.sh's run_c_interop_test) so the .so carries two libraries, the
+same "several libraries in one .so" path as tests/shared/*.vox — but here the
+consumer is a C driver (driver.c), pinning LANGUAGE.md's "or from C" and
+SYMBOL_MANGLING.md's "must be callable from C" promises. Mangles to
+math_kit_1_0_add_two; add_two(40) must be 42.)
+
+Library "math kit" version "1.0".
+
+To "add two" with a number called "x".
+  Return a number, x add 2.

--- a/tests/cinterop/strkit.vox
+++ b/tests/cinterop/strkit.vox
@@ -1,0 +1,9 @@
+(Paired with mathkit.vox; see there for the test this fixture belongs to.
+Exercises the text side of the C ABI: Vox text is NUL-terminated, so the
+returned pointer reads directly as a C `char *` with no marshalling. Mangles
+to strkit_1_0_greet.)
+
+Library "strkit" version "1.0".
+
+To "greet".
+  Return a text, "hello from vox".


### PR DESCRIPTION
`LANGUAGE.md` claims Vox `.so` libraries are callable from C twice (`:2843` "or from C", `:2880` "loadable from C, Rust, or any other host") and `docs/SYMBOL_MANGLING.md:66` a third time ("**must** be callable from C").

Nothing in the suite checked any of it — `grep -rlE '\.c\b|gcc' tests/ test.sh` came back empty — and `ROADMAP.md:142`'s *"Define and document a stable Vox ABI"* is still unticked. It worked by luck, not by contract.

## What this adds

`run_c_interop_test` in `test.sh` builds a `.so` with two exports (a numeric one and a text one), compiles a C driver against it with `gcc -Wall -Wextra -Werror -std=c11`, and runs it. It asserts:

- the `.so` has **zero `NEEDED` entries** — freestanding, pulling in no libc on the Vox side
- both mangled exports (`math_kit_1_0_add_two`, `strkit_1_0_greet`) are present in `.dynsym`
- the gcc build produces **zero warnings** (enforced via `-Werror`'s exit code)
- the driver's **exact stdout** (`42 hello from vox`), not merely its exit status

**No skip path.** `gcc` is required rather than optional: a gcc-conditional test would silently drop the only coverage of a documented guarantee on any host without it. Skip budget is unchanged.

**208 → 209 passed, 0 failed, 6 skipped** — verified independently, not taken on report.

## Findings surfaced while pinning this down

Neither is fixed here, but both are now known rather than latent:

- **`LANGUAGE.md:2951` is wrong.** It states `.lib` parameter and return types are "drawn from `number`, `text`, `boolean`, `file`, `value`; anything else is an error" — but `src/lib_file.rs:176-178` also accepts `buffer`, `list` and `map` in *parameter* position. The claim is only accurate for return position.
- **`float` cannot be expressed in a signature at all** — confirmed as both parameter (`Missing parameter name`) and return (`Expected a statement, got Float`). Not a C-interop gap as such, since Vox cannot state the signature in the first place.

Only `number` and `text` are now both documented *and* proven end to end by a C driver. `boolean` and `file` are plain integers internally and so are very likely safe by the same reasoning, but remain unexercised by an actual C caller.

🤖 Generated with [Claude Code](https://claude.com/claude-code)