### PR TITLE
Fix: Gate B .lib return-type silently drops to void

### DIFF
--- a/src/analyzer/mod.rs
+++ b/src/analyzer/mod.rs
@@ -1052,7 +1052,7 @@ impl Analyzer {
             Statement::Repeat { count, body } => self
                 .expr_uses_flag(count)
                 .or_else(|| body.iter().find_map(|s| self.statement_uses_flag(s))),
-            Statement::Return { value } => value.as_ref().and_then(|v| self.expr_uses_flag(v)),
+            Statement::Return { value, .. } => value.as_ref().and_then(|v| self.expr_uses_flag(v)),
             Statement::Exit { code } => self.expr_uses_flag(code),
             Statement::Allocate { size, .. } => self.expr_uses_flag(size),
             Statement::ByteSet { index, value, .. } => self.expr_uses_flag(index).or_else(|| self.expr_uses_flag(value)),
@@ -2157,7 +2157,7 @@ impl Analyzer {
                 self.loop_depth -= 1;
             }
             
-            Statement::Return { value } => {
+            Statement::Return { value, .. } => {
                 // `Return` is only meaningful inside a function. At top
                 // level the codegen still emits a function epilogue
                 // (leave/ret) which is undefined from _start, so reject

--- a/src/codegen/mod.rs
+++ b/src/codegen/mod.rs
@@ -3156,7 +3156,7 @@ impl CodeGenerator {
                 }
             }
             
-            Statement::Return { value } => {
+            Statement::Return { value, .. } => {
                 if let Some(v) = value {
                     self.generate_expr(v); // leaves return payload in RAX
                     // A `value` return carries its runtime tag in r11 for the
@@ -8083,6 +8083,57 @@ To hasflag with a number called n.\n  Return a number, n add 100.\n";
         let lib = super::render_lib_file(&blocks, "libflags.so");
         let expected = "Library flags version \"0.1\".\nLocation \"./libflags.so\".\n\nTable of Contents:\n    To hasflag with a number called n, returning a number.\n\nLibrary flags version \"1.0\".\nLocation \"./libflags.so\".\n\nTable of Contents:\n    To hasflag with a number called n, returning a number.\n";
         assert_eq!(lib, expected, "emitted .lib must match the normative format");
+    }
+
+    #[test]
+    fn lib_file_return_first_statement_still_carries_return_type() {
+        // Gate A regression: `Return` as the function's literal first
+        // statement is handled by a separate inline path in
+        // `parse_function_def`, not `parse_return`. This pins its output
+        // unchanged by the Gate B fix below.
+        let src = "\
+Library ga version \"1.0\".\n\
+To ga with a number called x.\n  Return a number, x.\n";
+        let (blocks, _exports) = compile_shared_with_libs(src);
+        let lib = super::render_lib_file(&blocks, "libga.so");
+        assert!(
+            lib.contains("To ga with a number called x, returning a number."),
+            "Return as the first statement must still record its return type; got:\n{}",
+            lib
+        );
+    }
+
+    #[test]
+    fn lib_file_return_after_other_statement_carries_return_type() {
+        // Gate B: `Return` follows a local declaration, so it's parsed by
+        // `parse_return`, not the inline first-statement path above. Before
+        // the fix, `parse_return` validated the type annotation but never
+        // wrote it back to `FunctionDef.return_type`, which stayed
+        // `Type::Void` — so the .lib ToC silently dropped the `, returning
+        // a <type>` clause for any function with real logic before its
+        // `Return`. Covers all three types Gate B accepts today.
+        let src = "\
+Library gb version \"1.0\".\n\
+To gbnum with a number called x.\n  a number called y is x add x.\n  Return a number, y.\n\
+To gbtext with a text called s.\n  a text called t is s.\n  Return a text, t.\n\
+To gbbool with a number called x.\n  a boolean called ok is true.\n  Return a boolean, ok.\n";
+        let (blocks, _exports) = compile_shared_with_libs(src);
+        let lib = super::render_lib_file(&blocks, "libgb.so");
+        assert!(
+            lib.contains("To gbnum with a number called x, returning a number."),
+            "a number return after a preceding statement must not evaporate to void; got:\n{}",
+            lib
+        );
+        assert!(
+            lib.contains("To gbtext with a text called s, returning a text."),
+            "a text return after a preceding statement must not evaporate to void; got:\n{}",
+            lib
+        );
+        assert!(
+            lib.contains("To gbbool with a number called x, returning a boolean."),
+            "a boolean return after a preceding statement must not evaporate to void; got:\n{}",
+            lib
+        );
     }
 
     #[test]

--- a/src/parser/ast.rs
+++ b/src/parser/ast.rs
@@ -348,6 +348,12 @@ pub enum Statement {
     
     Return {
         value: Option<Expr>,
+        // The type written in `Return a <type>, ...`, when present. Carried
+        // on the statement itself (rather than only being consulted where
+        // the statement is parsed) so that whichever code assembles the
+        // enclosing function's `FunctionDef.return_type` can read it back
+        // regardless of where in the body this Return sits.
+        declared_type: Option<Type>,
     },
     
     FunctionDef {

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -342,7 +342,7 @@ mod file_line_read_and_seek_tests {
             Statement::FunctionDef { body, .. } => {
                 assert_eq!(body.len(), 1);
                 match &body[0] {
-                    Statement::Return { value: Some(Expr::BinaryOp { op, .. }) } => {
+                    Statement::Return { value: Some(Expr::BinaryOp { op, .. }), .. } => {
                         assert!(matches!(op, BinaryOperator::Add));
                     }
                     other => panic!("Expected Return(BinaryOp Add), got {:?}", other),
@@ -388,6 +388,7 @@ mod file_line_read_and_seek_tests {
                                 left,
                                 right,
                             }),
+                        ..
                     } => {
                         assert!(matches!(&**left, Expr::BinaryOp { op: BinaryOperator::Add, .. }));
                         assert!(matches!(&**right, Expr::BinaryOp { op: BinaryOperator::Subtract, .. }));
@@ -2103,34 +2104,40 @@ impl Parser {
     fn parse_return(&mut self) -> Result<Statement, Box<CompileError>> {
         self.advance();
         self.skip_noise();
-        
+
         if matches!(self.current(), Token::Period | Token::EOF | Token::Newline) {
-            Ok(Statement::Return { value: None })
+            Ok(Statement::Return { value: None, declared_type: None })
         } else {
             // Handle "Return a type, expr." syntax (type declaration is optional)
             if matches!(self.current(), Token::A | Token::An) {
                 self.advance();
                 self.skip_noise();
-                
+
                 // Check if this is a type keyword followed by comma
                 if matches!(self.current(), Token::Number | Token::Text | Token::Boolean) {
+                    let declared_type = match self.current() {
+                        Token::Number => Type::Integer,
+                        Token::Text => Type::String,
+                        Token::Boolean => Type::Boolean,
+                        _ => unreachable!(),
+                    };
                     self.advance();
                     self.skip_noise();
-                    
+
                     if *self.current() == Token::Comma {
                         self.advance();
                         self.skip_noise();
                         // Now parse the actual return expression
                         let value = self.parse_expression()?;
-                        return Ok(Statement::Return { value: Some(value) });
+                        return Ok(Statement::Return { value: Some(value), declared_type: Some(declared_type) });
                     }
                 }
                 // If not "a type,", backtrack isn't possible, so error
                 return Err(self.err("Expected type after 'a' in return statement"));
             }
-            
+
             let value = self.parse_expression()?;
-            Ok(Statement::Return { value: Some(value) })
+            Ok(Statement::Return { value: Some(value), declared_type: None })
         }
     }
     
@@ -4237,6 +4244,7 @@ impl Parser {
                 self.skip_noise();
             }
             
+            let mut declared_type = None;
             if matches!(self.current(), Token::Number | Token::Text | Token::Boolean | Token::File)
                 || matches!(self.current(), Token::Identifier(ref n) if n == "value")
             {
@@ -4248,14 +4256,15 @@ impl Parser {
                     Token::Identifier(ref n) if n == "value" => { self.advance(); Type::Value }
                     _ => Type::Void,
                 };
+                declared_type = Some(return_type.clone());
                 self.skip_noise();
                 self.expect(&Token::Comma);
                 self.skip_noise();
             }
-            
+
             // Parse the return expression
             let expr = self.parse_condition()?;
-            body.push(Statement::Return { value: Some(expr) });
+            body.push(Statement::Return { value: Some(expr), declared_type });
         }
 
         // A top-level Return ends the function body. LANGUAGE.md states
@@ -4307,6 +4316,15 @@ impl Parser {
             }
             let stmt = self.parse_statement()?;
             let is_return = matches!(stmt, Statement::Return { .. });
+            // Gate B: `Return` isn't the function's first statement, so its
+            // type annotation (if any) was parsed by `parse_return` rather
+            // than inline above. Feed it back into the function's declared
+            // return type the same way the inline path above does, or a
+            // `Return a number, ...` that isn't the first statement would
+            // silently leave `return_type` at `Type::Void`.
+            if let Statement::Return { declared_type: Some(ref t), .. } = stmt {
+                return_type = t.clone();
+            }
             body.push(stmt);
 
             // A top-level Return parsed as a body statement terminates the

--- a/test.sh
+++ b/test.sh
@@ -266,13 +266,16 @@ run_shared_library_test() {
         exp=$(printf '%s\n' mathkit_1_0_add_two_numbers mathkit_1_0_greet mathkit_1_0_makebuf | sort)
         # 2b. A3: the .lib interface file is written beside the .so. Assert its
         #     exact content — a drift in the emitted format fails here, not at
-        #     A4. `makebuf` is a multi-statement body, so the parser does not
-        #     capture its return type (a known A3 gap, see the report); its ToC
-        #     entry reads `To makebuf.` with no `, returning` clause. The
-        #     other two are single-line defs whose typed `Return a number, ...`
-        #     is captured, so they carry `, returning a number`.
+        #     A4. `makebuf` is a multi-statement body (`Return` follows a
+        #     `Create`/`Append` pair, not the function's first statement), so
+        #     plan 280 S1's Gate B fix is what makes its ToC entry carry
+        #     `, returning a number` at all — before that fix, Gate B parsed
+        #     the typed `Return a number, ...` but never wrote it back into
+        #     the function's declared return type, so this entry silently
+        #     read `To makebuf.` (void). The other two are single-line defs
+        #     whose typed `Return a number, ...` was always captured (Gate A).
         local lib_exp
-        lib_exp=$(printf 'Library mathkit version "1.0".\nLocation "./libmath.so".\n\nTable of Contents:\n    To '\''add two numbers'\'' with a number called n, returning a number.\n    To greet.\n    To makebuf.\n')
+        lib_exp=$(printf 'Library mathkit version "1.0".\nLocation "./libmath.so".\n\nTable of Contents:\n    To '\''add two numbers'\'' with a number called n, returning a number.\n    To greet.\n    To makebuf, returning a number.\n')
         if ! diff -u <(printf '%s\n' "$lib_exp") "$work/libmath.lib" >"$work/libdiff.log" 2>&1; then
             fail_msg="shared/libmath (.lib content mismatch)"; fail_log="$work/libdiff.log"
         elif [[ "$got" != "$exp" ]]; then


### PR DESCRIPTION
A \`.lib\` built from a function whose \`Return\` isn't its first statement silently records \`Type::Void\` as the return type — the common case for any function with real logic before returning. Confirmed live against 0.3.0 before this fix:

\`\`\`
Library gb version "1.0".
To gb with a number called x.
  a number called y is x add x.
  Return a number, y.
\`\`\`

produced a \`.lib\` reading \`To gb with a number called x.\` — no \`, returning a number\` clause — even though \`gb\` genuinely returns a value. Same defect *shape* as everything 0.3.0 fixed (a library silently describing the wrong signature to its consumer); just not in scope for that pass. Diagnosed precisely by the plan 280 type audit's "Return position is two gates, not one" section.

## Root cause

\`Return\`'s type is parsed by two different paths depending on where it sits in the function body. Gate A (\`Return\` as the literal first statement, handled inline in \`parse_function_def\`) already wrote the parsed type into the enclosing \`FunctionDef.return_type\`. Gate B (\`Return\` after any other statement, routed through \`parse_return\`) parsed and validated the same annotation but never fed it back — \`return_type\` silently stayed \`Type::Void\`.

## Fix

\`Statement::Return\` now carries the type it was declared with (\`declared_type: Option<Type>\`), populated by both parsing paths. \`parse_function_def\`'s body loop reads it back off the terminal \`Return\` statement to set \`return_type\`, mirroring what Gate A already did directly. An untyped \`Return expr.\` still correctly yields \`Type::Void\`.

Deliberately scoped narrowly: this fixes the silent-void bug for the 3 types Gate B already accepts (\`number\`/\`text\`/\`boolean\`). It does **not** expand Gate B's type vocabulary — that's separate, not-yet-started work (plan 280 S2/S3, \`float\`/\`time\`/\`list\`/\`map\`/\`buffer\`/\`value\`/\`file\`, plus a design decision needed for \`timer\`).

A golden \`test.sh\` fixture (\`tests/shared/libmath\`'s \`makebuf\`) had baked this exact bug in as documented, expected behaviour — its comment explicitly called it "a known A3 gap." Updated the fixture and the comment to the correct, now-verified output. This is fixing a fixture that encoded a bug, not weakening a test.

## Verified independently before this PR, not taken on the implementing worker's report

- The exact repro above, rebuilt from a forced-clean build, contrasted directly against the unfixed baseline (which still shows the old bug) — side by side, not just "compiles."
- \`cargo test\`: 176 passed / 0 failed (includes 2 new regression tests: Gate A unaffected, Gate B correct across all 3 accepted types).
- \`./test.sh\`: 209 passed / 0 failed / 6 skipped.
- 0 build warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)