### PR TITLE
Revert VS Code extension version bump for 0.3.1

### DIFF
--- a/vox-vscode/package.json
+++ b/vox-vscode/package.json
@@ -2,7 +2,7 @@
   "name": "vox",
   "displayName": "Vox syntax highlighting",
   "description": "Syntax highlighting for Vox (sentence based code) (.vox files)",
-  "version": "0.3.1",
+  "version": "0.3.0",
   "publisher": "vox-lang",
   "engines": {
     "vscode": "^1.75.0"


### PR DESCRIPTION
0.3.1 was a compiler-only patch — Gate B `.lib` return-type fix. `vox-vscode/`'s only diff between v0.3.0 and v0.3.1 was the version number itself, no grammar or functional change. Already removed the `.vsix` I'd mistakenly attached to the v0.3.1 GitHub release; this reverts the version field so it stops claiming a package that was never actually built or shipped.