### PR TITLE
Fix variable re-type bugs: lock a variable's type at its declaration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,49 @@ All notable changes to Vox are documented here. The format is based on
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project
 adheres to [Semantic Versioning](https://semver.org/).
 
+## [0.3.3] - 2026-08-08
+
+### Fixed
+
+- **Reassigning a variable to a value of a different type could silently
+  produce a wrong number, or segfault** — the compiler's tracked type for a
+  variable could disagree with what the variable actually held at runtime,
+  and formatting/printing code trusted the tracked type. Depending on the
+  direction of the mismatch this either printed a pointer address as if it
+  were a number, or dereferenced a raw number as if it were a string
+  pointer and crashed:
+
+  ```
+  a number called n is 5.
+  n is "abc".
+  Print "{n}".        -> printed a garbage number; could also segfault
+                          depending on which way the mismatch ran
+  ```
+
+  A variable's type is now fixed at its declaration and never changes. A
+  write that would change it — `n is "abc".`, `the n is "abc".`, or `Set n
+  to "abc".`, and reusing an already-declared name as a loop variable, an
+  `open ... called` target, or an `Allocate ... for` target — is now a
+  compile error instead:
+
+  ```
+  n is "abc".   -> error: cannot assign text to 'n', which is a number
+                    help: convert it explicitly:  n is "abc" as a number.
+  ```
+
+  **If a program you have relies on this**, convert the value explicitly
+  with `as a number` / `as text` / `as a float` / `as a boolean` at the
+  point of assignment — this syntax already existed and is unchanged. A
+  variable declared `a value called x` is unaffected and keeps accepting
+  any type, as documented.
+
+  This also closes several related cases with the same root cause:
+  incrementing or decrementing a text variable, a declaration inside an
+  untaken `If`/`Otherwise`/`While`/`Repeat`/`for` branch or an `on error`
+  handler that never fires, a nested declaration that reuses an outer
+  variable's name with a different type, and reading a mismatched value out
+  of a map whose value type is provable from its own literal.
+
 ## [0.3.2] - 2026-08-07
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -59,7 +59,7 @@ checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
 name = "vox"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "thiserror",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vox"
-version = "0.3.2"
+version = "0.3.3"
 edition = "2021"
 rust-version = "1.87"
 description = "A systems level compiler for Vox (sentence based code)"

--- a/LANGUAGE.md
+++ b/LANGUAGE.md
@@ -350,6 +350,78 @@ the x is 10.
 the counter is the counter add 1.
 ```
 
+### Type Immutability
+
+**A variable's type is fixed at its declaration and never changes.** Every
+form that writes to an already-declared name — `x is <value>.`, `the x is
+<value>.`, and `Set x to <value>.` — is checked the same way: if the new
+value's type doesn't match the type `x` was declared with, that's a compile
+error, not a silent retype.
+
+```vox fragment
+a number called n is 5.
+n is "abc".              → compile error: cannot assign text to 'n', which is a number
+n is "42" as a number.   → OK: n is now 42
+```
+
+The error names the variable, its declared type and where it was declared,
+the type of the value that doesn't match, and the exact cast that would fix
+it:
+
+```
+error: cannot assign text to 'n', which is a number
+  --> prog.vox:2:1
+   |
+ 2 | n is "abc".
+   | ^ this assigns text
+   |
+  note: 'n' was declared as a number at prog.vox:1:17
+  help: convert it explicitly:  n is "abc" as a number.
+```
+
+Convert explicitly with [Type Casting](#type-casting) (`as a number` / `as
+text` / ...) — the same mechanism used everywhere else in the language, not
+new syntax for this rule.
+
+This isn't limited to reassignment. Any construct that binds a name to a new
+runtime value is checked the same way: reusing an already-declared name as a
+`For each`/for-range loop variable, as the target of `open ... called`, or
+as the target of `Allocate ... for` all reject a type that conflicts with
+the name's existing declaration. So does a nested declaration that reuses an
+outer name with a different type (Vox has no block-level scoping today, so
+there is no separate slot for the inner declaration to occupy):
+
+```vox fragment
+a number called n is 5.
+If 1 is equal to 2,
+  a text called n is "abc".   → compile error: 'n' is already declared as a number
+```
+
+**Two exemptions, both deliberate:**
+
+- **Buffers.** Writing into a buffer (`b is 42.`, `Set b to "text".`) copies
+  the value's text representation into the buffer's content — a format
+  operation, not a type change — so a buffer accepts any value type on every
+  write.
+- **`value`.** A variable declared `a value called x` is the language's
+  sanctioned dynamic type and keeps accepting any type across reassignment,
+  exactly as documented in [Dynamic Values (`value`)](#dynamic-values-value)
+  below — that section's behavior is unchanged by this rule, not an
+  exception carved out of it.
+
+**What this doesn't catch.** The check only rejects a mismatch it can prove
+statically from the value's own shape (a literal, a cast, a read from a
+list/map whose element type is provably uniform, ...). A value coming from
+a function call, an unprovable list/map read (a map literal with mixed
+value types, for instance), or anything else the compiler can't classify at
+compile time is allowed through unchecked, exactly as it was before this
+rule. This closes a large, concrete class of bugs — a variable's compiler-
+tracked type disagreeing with what it actually holds at runtime, which
+previously produced a wrong number on screen at best and a segfault at
+worst — not every possible source of type confusion, and it says nothing
+about type agreement across a `.lib` import boundary (a library's declared
+signature is currently trusted, not verified against its `.so`).
+
 ### Naming Rules
 
 A name is an **identifier**, never a string literal. Three forms, no overlap,
@@ -1169,20 +1241,44 @@ set r to 7.
 If r is a number, print "now a number".
 ```
 
-**A `value` is not usable in arithmetic without checking its type first.**
-Because a `value` might hold a string or a decimal, the compiler rejects
-bare arithmetic on it and points you at the predicate idiom:
+**A `value` is not usable in arithmetic, and cannot currently be
+converted.** Because a `value` might hold a string or a decimal, the
+compiler rejects bare arithmetic on it:
 
 ```
 To bump with a value called v. Return a number, v add 1.
-(compile error: Cannot use a value v in arithmetic; check its type with
- 'is a number'/'is a text' first.)
+(compile error: Cannot use a value v in arithmetic; convert it explicitly
+ first with 'as a number' or 'as text'.)
 ```
 
-Guard it first — `if v is a number, … v add 1 …` — or cast it with
-`v as a number` (see Type Casting). (Full flow-sensitive dispatch — where a
-guard narrows the type *inside* the branch so `v add 1` just works — is a
-later decision; see the roadmap.)
+The error's own advice doesn't fully work yet, and it's worth knowing why
+rather than hitting a wall silently: neither of the two paths that would
+normally apply currently narrows or converts a `value` whose tag is only
+known at runtime.
+
+- **A type-predicate guard does not narrow.** `if v is a number, … v add 1
+  …` still rejects `v add 1` *inside* the `If` body — the guard proves the
+  branch is live only when the tag matches, but nothing today propagates
+  that proof into `v`'s tracked type for the statements inside it. Full
+  flow-sensitive narrowing is a later decision; see the roadmap.
+- **A cast is also rejected, deliberately, rather than silently computing
+  garbage.** `v as a number` cannot currently be relied on either: the
+  runtime-tag dispatch that would make it convert correctly (parse the
+  string when the tag says text, pass the integer through when it says
+  number, ...) doesn't exist in codegen yet, so a cast on a `value` whose
+  tag isn't known at compile time is a compile error rather than a
+  conversion that would sometimes silently produce the wrong number. (A
+  `value` whose tag genuinely *is* knowable at compile time — one holding a
+  literal number right where it's declared, for instance — is still
+  dynamically typed by declaration and gets the same rejection; the
+  compiler does not special-case it.)
+
+Both are open, tracked gaps (plan 294 finding 21), not present behavior to
+route around. There is currently no supported way to convert or narrow a
+genuinely dynamically-tagged `value` from within the language — the
+predicate idiom (`is a number` / `is a text`) remains useful for branching
+and for `Print`, which does dispatch correctly on the runtime tag; it just
+does not yet unlock arithmetic or casting inside the branch it guards.
 
 **Recursion with `value` works.** A `value` parameter threads its tag
 through every frame, so a recursive walker over mixed data classifies

--- a/LANGUAGE.md
+++ b/LANGUAGE.md
@@ -394,7 +394,8 @@ there is no separate slot for the inner declaration to occupy):
 ```vox fragment
 a number called n is 5.
 If 1 is equal to 2,
-  a text called n is "abc".   → compile error: 'n' is already declared as a number
+  a text called n is "abc".   → compile error: cannot bind 'n' to text in this
+                                 declaration; 'n' is already declared as a number
 ```
 
 **Two exemptions, both deliberate:**
@@ -1241,41 +1242,39 @@ set r to 7.
 If r is a number, print "now a number".
 ```
 
-**A `value` is not usable in arithmetic, and cannot currently be
-converted.** Because a `value` might hold a string or a decimal, the
-compiler rejects bare arithmetic on it:
+**A `value` is not usable in arithmetic, and cannot currently be converted
+or narrowed either.** Because a `value` might hold a string or a decimal,
+the compiler rejects bare arithmetic on it:
 
 ```
 To bump with a value called v. Return a number, v add 1.
-(compile error: Cannot use a value v in arithmetic; convert it explicitly
- first with 'as a number' or 'as text'.)
+(compile error: Cannot use a value v in arithmetic: its type is only known
+ at runtime, and arithmetic on a dynamically-tagged value is not currently
+ supported.)
 ```
 
-The error's own advice doesn't fully work yet, and it's worth knowing why
-rather than hitting a wall silently: neither of the two paths that would
-normally apply currently narrows or converts a `value` whose tag is only
-known at runtime.
+This is a real, open gap (plan 294 finding 21), not just an unhelpful
+message — the two paths that would normally get you out of a check like
+this don't currently work for a `value` whose tag is only known at
+runtime, and it's worth knowing why rather than hitting a wall twice:
 
 - **A type-predicate guard does not narrow.** `if v is a number, … v add 1
   …` still rejects `v add 1` *inside* the `If` body — the guard proves the
   branch is live only when the tag matches, but nothing today propagates
   that proof into `v`'s tracked type for the statements inside it. Full
   flow-sensitive narrowing is a later decision; see the roadmap.
-- **A cast is also rejected, deliberately, rather than silently computing
-  garbage.** `v as a number` cannot currently be relied on either: the
-  runtime-tag dispatch that would make it convert correctly (parse the
-  string when the tag says text, pass the integer through when it says
-  number, ...) doesn't exist in codegen yet, so a cast on a `value` whose
-  tag isn't known at compile time is a compile error rather than a
-  conversion that would sometimes silently produce the wrong number. (A
-  `value` whose tag genuinely *is* knowable at compile time — one holding a
-  literal number right where it's declared, for instance — is still
-  dynamically typed by declaration and gets the same rejection; the
-  compiler does not special-case it.)
+- **A cast is rejected outright, deliberately, rather than silently
+  computing garbage.** `v as a number` used to compile but skip the
+  conversion when the tag didn't already match the target's native
+  representation — a text pointer reinterpreted as an integer, not parsed.
+  Casting a `value` whose tag isn't known at compile time is now a compile
+  error instead. (A `value` whose tag genuinely *is* knowable at compile
+  time — one holding a literal number right where it's declared, for
+  instance — is still dynamically typed by declaration and gets the same
+  rejection; the compiler does not special-case it.)
 
-Both are open, tracked gaps (plan 294 finding 21), not present behavior to
-route around. There is currently no supported way to convert or narrow a
-genuinely dynamically-tagged `value` from within the language — the
+There is currently no supported way to use, convert, or narrow a genuinely
+dynamically-tagged `value` in arithmetic from within the language. The
 predicate idiom (`is a number` / `is a text`) remains useful for branching
 and for `Print`, which does dispatch correctly on the runtime tag; it just
 does not yet unlock arithmetic or casting inside the branch it guards.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,6 +1,6 @@
 # Vox Roadmap: From Today to a Kernel Written in Vox
 
-This roadmap charts the path from the current state of Vox (v0.2.0) to the
+This roadmap charts the path from the current state of Vox (v0.3.3) to the
 long-term goal: a memory-safe, sentence-based systems language capable of
 expressing *any* program — including cryptographic libraries, network stacks,
 device drivers, and ultimately an operating system kernel — across multiple
@@ -62,6 +62,18 @@ graph LR
 - [ ] Adopt the compile-time safety goals in
       [docs/segfault-safety-test-plan.md](docs/segfault-safety-test-plan.md):
       no valid Vox program may segfault at runtime.
+- [x] **Fix the compiler-tracked-type-vs-runtime-type divergence family.**
+      *(Fixed in v0.3.3. A variable's type is now fixed at its declaration
+      and locked for good — a type-differing write is a compile error, not a
+      silent retype. This closed 18 confirmed findings across the class,
+      documented in `docs/plans/294_retype_audit.md`; see LANGUAGE.md's "Type
+      Immutability" section for the user-facing rule. Two things this does
+      NOT close, tracked as their own follow-ups in the same audit: casting a
+      dynamically-tagged `value` still can't convert (finding 21 — currently
+      a compile error instead of a silent wrong answer, which is the safe
+      state, but the conversion itself isn't implemented), and a `.lib`'s
+      declared signature is trusted, not verified against its `.so` (audit
+      section C).)*
 
 **Exit criteria:** the full test suite passes; no known program written in
 documented Vox can crash the generated binary.

--- a/docs/plans/294_retype_audit.md
+++ b/docs/plans/294_retype_audit.md
@@ -1,0 +1,842 @@
+# Plan 294 — retype audit, and implementation checklist for type immutability
+
+**Status:** audit only. **No `src/` changes.** A separate worker owns `src/`
+and is implementing the type-immutability rule; another is fixing Bug B.
+
+**Tree:** branch `retype-audit`, base `409bd2c`.
+
+This document has two jobs:
+
+1. **Findings** — every place the compiler's tracked type disagrees with the
+   variable's actual runtime type. 18 findings, each with a runnable
+   reproduction under `tests/retype_audit_pocs/`.
+2. **Implementation checklist** — every site where a variable can be bound,
+   assigned, or have its type inferred, for the team enforcing the new rule
+   that **a variable's type is fixed at its declaration**.
+
+## Baseline
+
+Recorded before any work. All three match the expected numbers.
+
+| check | result |
+|---|---|
+| `cargo build --release` | clean, **0 warnings** |
+| `cargo test --release` | **189 passed / 0 failed** (174 + 7 + 4 + 3 + 1) |
+| `./test.sh` | **219 passed / 0 failed / 6 skipped** (total 225) |
+| `git status` | clean |
+
+---
+
+## Headline — the rule closes 9 of 18 findings; 9 survive it
+
+This is the part worth reading first. Under the new rule (type fixed at
+declaration; a type-changing assignment becomes a compile error pointing at an
+explicit cast; `Type::Value`/`VarType::Mixed` remains the sanctioned dynamic
+type), the findings split cleanly:
+
+**Closed by the rule (9)** — findings 1, 6, 7, 8, 9, 10, 11, 13, 16.
+
+All the flow-insensitivity findings are in this group, and they are closed
+*elegantly*: if no assignment may change a variable's type, then the tracked
+type never changes after declaration, so it cannot drift out of agreement with
+runtime regardless of which branch executed. **Flow-insensitivity stops
+mattering because there is nothing left for it to get wrong.** That is the
+single strongest technical argument for the rule.
+
+**Survives the rule (9)** — findings 2, 3, 4, 5, 12, 14, 15, 17, 18.
+
+These survive because **the rule constrains assignment, and these are not
+assignments.** They are: other statements that rebind a name (loop variables,
+`open ... called`, `Allocate`), operations that ignore the type rather than
+change it (`Increment`/`Decrement`), reads whose type cannot be inferred (map
+values), scope machinery that never restores an outer type (nested
+shadowing), and the genuinely dynamic case (heterogeneous list iteration).
+
+Two structural reasons underlie the whole "survives" column, and both need a
+deliberate decision:
+
+- **A binding is not the same thing as an assignment.** Six statement forms
+  put a new runtime value into an existing name without going through
+  `Statement::Assignment`. If enforcement is added only to the assignment
+  path, all of them still produce the same segfaults they do today.
+- **Some types genuinely cannot be fixed.** Map value types are *never*
+  inferred anywhere in the compiler (`Type::Map(Box::new(Type::Unknown))` at
+  `src/analyzer/mod.rs:1315`, `1547`, `1761`, `1768`), and a heterogeneous
+  list's elements differ per iteration. For these, "fixed type" is the wrong
+  answer and the `value`/Mixed mechanism is the right one.
+
+There is also a trap in the *closed* column: findings 1, 13 and 16 are closed
+**only if enforcement is placed on the `VarDecl { var_type: None }`
+re-declaration path**, which is precisely the path that currently forgets to
+update the type at all. Enforcing on `Statement::Assignment` alone leaves
+`Set`/`Store`/`Assign`/`Create` still segfaulting.
+
+---
+
+## Findings
+
+Severity is by runtime consequence. PoC directory numbering matches this
+order. Every `poc.sh` **exits 0 if and only if the bug is present**, so it
+flips to non-zero once fixed. Run them all:
+
+```bash
+cd tests/retype_audit_pocs
+for d in [0-9]*/; do ./"$d"/poc.sh >/dev/null 2>&1 && echo "BUG PRESENT $d" || echo "fixed/absent $d"; done
+```
+
+Both directions of that contract were verified, not assumed: a
+`poc_expect_segv` script run against a healthy program exits 1
+(`NOT REPRODUCED: exit=0 output=[abc]`), and a `poc_expect_not` script run
+against correct output exits 1. Exit 3 is reserved for "could not run the
+experiment" so infrastructure failure never reads as "bug present".
+
+| # | sev | construct | consequence | under the new rule |
+|---|---|---|---|---|
+| 1 | **crit** | `Set X to <number>` where `X` is text | SIGSEGV | **closed** *if enforced on the `VarDecl{None}` path* |
+| 2 | **crit** | for-range loop variable reusing a text name | SIGSEGV | **SURVIVES** — a binding, not an assignment |
+| 3 | **crit** | `open a file ... called X` over a text name | SIGSEGV | **SURVIVES** — a binding, not an assignment |
+| 4 | **crit** | text variable assigned a numeric map value | SIGSEGV | **SURVIVES** — map value types are never inferred |
+| 5 | **crit** | `Increment` on a text variable | pointer walk → SIGSEGV | **SURVIVES** — no type change, an invalid operation |
+| 6 | **crit** | assignment in an untaken `If` branch | SIGSEGV (Bug A) | **closed** |
+| 7 | **crit** | assignment in an untaken `Otherwise` branch | SIGSEGV | **closed** |
+| 8 | **crit** | assignment in a `While` body that never runs | SIGSEGV | **closed** |
+| 9 | **crit** | assignment in a `Repeat 0 times` body | SIGSEGV | **closed** |
+| 10 | **crit** | assignment in a for-range body over an empty range | SIGSEGV | **closed** |
+| 11 | **crit** | assignment in an `on error` handler that never fires | SIGSEGV | **closed** |
+| 12 | **crit** | *declaration* in an untaken branch | SIGSEGV | **SURVIVES** — needs real nested-scope shadowing |
+| 13 | **high** | `Set X to <text>` where `X` is a number (Bug B) | pointer as integer | **closed** *same caveat as 1* |
+| 14 | **high** | number variable assigned a text map value | pointer as integer | **SURVIVES** — map value types are never inferred |
+| 15 | **high** | `Decrement` on a text variable | out-of-bounds read | **SURVIVES** — no type change, an invalid operation |
+| 16 | **med** | arithmetic after `Set` retypes a text variable | spurious compile error | **closed** by redefinition |
+| 17 | **low** | `Allocate N for X` over a text name | stale text tracking | **SURVIVES** — a binding, not an assignment |
+| 18 | **high** | arithmetic on a for-each variable over a *heterogeneous* list | pointer as integer | **SURVIVES** — this is the Mixed case |
+
+### 1 — critical — `Set X to <number>` on a text variable
+
+```vox
+a text called s is "hello".
+Set s to 5.
+Print "{s}".
+```
+
+Observed **SIGSEGV, exit 139**; expected `5`.
+
+This is Bug B's root cause in the memory-unsafe direction, and it is why Bug B
+should not be filed as merely "silently wrong output".
+`Set`/`Store`/`Assign`/`Create` do **not** parse to `Statement::Assignment`.
+They route through `Token::Set => self.parse_var_decl()`
+(`src/parser/mod.rs:944`; `Create` at `:972`) and exit at
+`src/parser/mod.rs:1453` as `Statement::VarDecl { var_type: None }` — a
+*re-declaration* carrying no declared type.
+
+Both consumers then skip their type update, because both guard on the declared
+type being present:
+
+- analyzer `src/analyzer/mod.rs:1987` — `if let Some(vt) = var_type`, so with
+  `None` neither the insert at 1994/2002 nor the remove at 2004 runs.
+- codegen `src/codegen/mod.rs:2696` — `if let Some(ref t) = var_type`, so the
+  insert at 2711 does not run. The value-driven fallbacks at 2718-2786 do not
+  cover a bare literal: a `StringLit` only inherits a type when it names an
+  existing variable (2776).
+
+The runtime store happens regardless, so the slot holds an integer while
+`variable_types[s]` still says `String`. `resolve_format_variable`
+(`src/codegen/mod.rs:664-725`, reading `variable_types` at 703/706) emits a
+string-pointer dereference against the raw integer `5`.
+
+All four spellings confirmed: `Set`, `Store`, `Assign` (all lex to `Token::Set`
+at `src/lexer/mod.rs:773`) and `Create`. **Verify any fix against all four.**
+
+> **Under the new rule:** closed — the assignment changes the type, so it
+> becomes a compile error. **But only if the check is placed on the
+> `VarDecl { var_type: None }` path.** This path is invisible to any
+> enforcement written against `Statement::Assignment`, and it is the one that
+> currently segfaults.
+
+### 2 — critical — for-range loop variable reusing a text name
+
+```vox
+a text called i is "hello".
+For each i from 1 to 3,
+  Print "in {i}".
+```
+
+Observed: prints `in ` then **SIGSEGV**; expected `in 1 / in 2 / in 3`.
+
+**The two maps disagree with each other.** The analyzer *does* retype the loop
+variable to `Integer` (`src/analyzer/mod.rs:2151`), but codegen's
+`Statement::ForRange` arm (`src/codegen/mod.rs:3032-3069`) **never writes
+`variable_types` at all** — it allocates the slot and emits the counter, and
+that is it. Its siblings do: the for-each-over-arguments path inserts `String`
+(`:3410`) and the for-each-over-list path inserts the element type (`:3520`).
+
+Because the analyzer is correct here, nothing can be flagged at compile time —
+the defect is entirely inside codegen.
+
+> **Under the new rule:** **survives.** Binding a loop variable is not an
+> assignment, so no assignment check sees it. Enforcement must either reject
+> reusing a text name as a numeric loop variable, or give the loop variable
+> its own scoped binding that shadows the outer name (and restores it on
+> exit). Either way codegen's `ForRange` arm has to start recording a type,
+> which it does not do today at all.
+
+### 3 — critical — `open a file ... called X` over a text name
+
+```vox
+a text called src is "hello".
+open a file for reading called src at "/etc/hostname".
+Print "[{src}]".
+```
+
+Observed: prints `[` then **SIGSEGV**.
+
+`FileOpen` stores a file descriptor into the named slot. Neither side clears
+the stale text label: the analyzer (`src/analyzer/mod.rs:2563-2569`) inserts
+into `variables` and `file_variables` but never touches `scalar_types`, and
+codegen's arm (`src/codegen/mod.rs:3974+`) contains no `variable_types` write
+at all (verified by grep over its range). `variable_types[src]` stays `String`
+and the fd is dereferenced as a `char*`.
+
+> **Under the new rule:** **survives**, for the same reason as finding 2 —
+> `open ... called X` is a binding site, not an assignment. It must either
+> reject rebinding a name already declared as text, or be treated as a
+> declaration of a `file`-typed variable.
+
+### 4 — critical — text variable assigned a numeric map value
+
+```vox
+a map called m is {"k": 42}.
+a text called s is "hello".
+s is m's "k".
+Print "[{s}]".
+```
+
+Observed: prints `[` then **SIGSEGV**; expected `[42]`.
+
+The analyzer takes the `None` arm and *removes* the label
+(`src/analyzer/mod.rs:2084-2086`) — correct and conservative. Codegen's
+`Assignment` arm only overwrites `variable_types` when `infer_expr_type`
+returns `Some` (`src/codegen/mod.rs:2922`); a map access infers to
+`Unknown`, and `VarType::Unknown` is an explicit no-op at
+`src/codegen/mod.rs:2931`. The stale `String` survives.
+
+> **Under the new rule:** **survives.** The rule says a type-changing
+> assignment is an error — but the compiler cannot tell that this assignment
+> changes the type, because **no map is ever given a value type**:
+> `Type::Map(Box::new(Type::Unknown))` is constructed at
+> `src/analyzer/mod.rs:1315`, `1547`, `1761` and `1768`, and nothing ever
+> refines it. See "where a fixed type is the wrong answer" below.
+
+### 5 — critical — `Increment` on a text variable
+
+```vox
+a text called s is "hi".
+Repeat 200000 times,
+  Increment s.
+
+Print "[{s}]".
+```
+
+Observed: **SIGSEGV.**
+
+`Increment` emits an integer `inc` against a slot holding a string pointer,
+with no check that the tracked type is numeric. The pointer is walked forward
+one byte at a time with no relationship to the string's bounds; enough
+iterations leave the mapping. A single `Increment s.` on `"hello"` prints
+`ello` — the same defect, one byte in, which is how to recognise it in the
+wild.
+
+> **Under the new rule:** **survives, and is not addressed by it at all.**
+> Tracking here is *correct* — `s` really is text and stays text. The rule
+> governs what may change a type; this is an operation that ignores the type.
+> `Increment`/`Decrement` need their own numeric-target check. The machinery
+> exists and produces good messages already (finding 16 shows arithmetic
+> rejecting a text operand), so this is cheap and independent of the rework.
+
+### 6-11 — critical — flow-insensitive tracking across every non-linear path
+
+Six findings, one root cause, differing only in the construct that creates the
+unexecuted path. Finding 6 is Bug A, analysed in
+`docs/plans/293_flow_insensitive_type_confusion_followup.md` and not repeated
+here. The point of 7-11 is **blast radius**: it is not an `If` bug.
+
+| # | construct | repro shape |
+|---|---|---|
+| 6 | `If` branch not taken | `If g is equal to 1,` with `g` = 0 |
+| 7 | `Otherwise` branch not taken | `If g is equal to 1,` with `g` = 1 |
+| 8 | `While` body never entered | `While g is equal to 1,` with `g` = 0 |
+| 9 | `Repeat 0 times` | count is 0 |
+| 10 | for-range over an empty range | `For each k from 1 to 0,` |
+| 11 | `on error` handler, no error | the `open` succeeds |
+
+All six go through the analyzer's `Assignment` arm
+(`src/analyzer/mod.rs:2080-2087`) and codegen's
+(`src/codegen/mod.rs:2922-2933`). The mechanism: `scalar_types` and
+`variable_types` are flat `HashMap`s with no branch discipline.
+`Statement::If` in the analyzer (`src/analyzer/mod.rs:2091-2136`) *does*
+carefully snapshot, branch and merge — but only `AnalysisEnv`, which tracks
+**variable availability**, not types. Types ride straight through the merge
+untouched. `While`, `ForRange`, `ForEach` and `Repeat` (2138-2183) do not even
+snapshot.
+
+> **Under the new rule:** **all six closed.** No assignment may change a
+> type, so the tracked type never diverges from the declared one and
+> flow-sensitivity becomes unnecessary for *this* purpose. Note it is still
+> needed for variable *availability*, which the existing `AnalysisEnv` merge
+> already handles correctly.
+
+### 12 — critical — a declaration in an untaken branch
+
+```vox
+a number called n is 5.
+If 1 is equal to 2,
+  a text called n is "abc".
+
+Print "outer [{n}]".
+```
+
+Observed: prints `outer [` then **SIGSEGV**; expected `outer [5]`.
+
+A **distinct code path** from findings 6-11: this goes through the `VarDecl`
+arms (`src/analyzer/mod.rs:2002`, `src/codegen/mod.rs:2711`), not the
+assignment arms.
+
+The related *taken*-branch case shows why this is really a scoping problem:
+with `1 is equal to 1`, the inner declaration overwrites the outer `n`
+entirely and `Print` after the block yields `abc`. There is no separate slot
+and no restore on scope exit.
+
+> **Under the new rule:** **survives.** Everything depends on a decision the
+> rule does not make: is an inner `a text called n` a *re-declaration* of the
+> outer `n` (→ compile error, since the type differs) or a *shadowing*
+> declaration of a new variable (→ legal, but it needs its own slot and the
+> outer type must be restored at scope exit)? Today it is neither — it reuses
+> the outer slot and permanently changes the outer type. Whichever answer is
+> chosen must be implemented; the rule alone does not pick one.
+
+### 13 — high — `Set X to <text>` on a number variable (Bug B)
+
+```vox
+a number called n is 5.
+Set n to "abc".
+Print "{n}".
+```
+
+Observed `4198480`; expected `abc` (the plain form `n is "abc".` prints
+`abc`). Same root cause as finding 1, benign direction. **A separate worker
+owns this fix; this track does not touch it.**
+
+> **Under the new rule:** closed, with finding 1's caveat. Note the rule
+> *changes the expected output*: `n is "abc".` on a number stops being legal
+> Vox and becomes a compile error too. The premise "reassigning a number to
+> text is legal Vox" — true today, and the reason Bug B is a bug rather than
+> invalid code — is exactly what the rule repeals.
+
+### 14 — high — number variable assigned a text map value
+
+```vox
+a map called m is {"k": "abc"}.
+a number called n is 5.
+n is m's "k".
+Print "{n}".
+```
+
+Observed `4198548` (the string's address); expected `abc`. Finding 4's benign
+direction, same lines.
+
+> **Under the new rule:** **survives** — identical reasoning to finding 4.
+
+### 15 — high — `Decrement` on a text variable
+
+```vox
+a text called s is "hello".
+Decrement s.
+Print "[{s}]".
+```
+
+Observed `[]`; expected `[hello]` or a diagnostic. The pointer is moved to
+*before* the start of the string literal and the formatter reads from there.
+Here the preceding byte happened to be `0`; what it lands on is a property of
+`.rodata` layout, not of the program. Rated high rather than critical only
+because a single decrement rarely leaves the page — finding 5 is the same
+defect made to crash.
+
+> **Under the new rule:** **survives** — see finding 5.
+
+### 16 — medium — spurious compile error after a `Set` retype
+
+```vox
+a text called s is "hello".
+Set s to 7.
+a number called z is 0.
+z is s add 1.
+Print "{z}".
+```
+
+Observed a **compile error**: `Cannot use text s in arithmetic; cast it first
+with 'as a number' or 'as a float'.` At runtime `s` holds `7`, so the
+arithmetic is valid; the analyzer rejects it because `scalar_types[s]` is
+still `String`.
+
+> **Under the new rule:** **closed by redefinition.** The program becomes
+> invalid at line 2 rather than line 4, and the diagnostic moves to the real
+> mistake. Worth noting the error message quoted above is already the shape
+> the new rule wants — it names the variable and points at the cast syntax.
+
+### 17 — low — `Allocate N for X` over a text name
+
+```vox
+a text called p is "hello".
+Allocate 100 for p.
+Print "{p}".
+```
+
+Observed: prints nothing; expected the pointer as a number. The analyzer
+correctly drops the label (`src/analyzer/mod.rs:2214`, with a comment saying
+why), but codegen's `Allocate` arm never updates `variable_types`, so it stays
+`String` and the formatter reads the fresh allocation as a C string.
+
+**Why currently unobservable:** freshly-mapped pages are zero-filled, so the
+read terminates on the first byte. It is one allocator change away from
+becoming a wild read — if `Allocate` ever serves recycled memory (a free list,
+an arena, a bump allocator over reused pages), this same program reads
+uninitialised heap until it finds a zero byte.
+
+> **Under the new rule:** **survives** — a binding, not an assignment, exactly
+> like findings 2 and 3.
+
+### 18 — high — arithmetic on a for-each variable over a heterogeneous list
+
+```vox
+a list called data is [42, "hello"].
+For each item in data,
+  a number called z is item add 1,
+  Print "z={z}".
+```
+
+Observed:
+
+```
+z=43
+z=4198529
+```
+
+Expected: either `43` and a meaningful second value, or a diagnostic. The
+first iteration is correct arithmetic; the second uses the *address* of
+`"hello"` as an integer operand.
+
+**Printing the same variable is correct** — `Print "{item}"` over
+`[42, "hello", 3.14]` yields `42 / hello / 3.14`, because the print path
+dispatches on the element's runtime tag held in `mixed_tag_slots`. Arithmetic
+does not consult that tag at all. That asymmetry is what makes this easy to
+miss.
+
+The analyzer *deliberately* clears the loop variable's label
+(`src/analyzer/mod.rs:2167`), with a comment explaining the intent: a stale
+label from a previous use of the name must not falsely reject arithmetic. That
+is right for a homogeneous list and unsound for a heterogeneous one.
+
+> **Under the new rule:** **survives, and it is the case where a fixed type is
+> the wrong answer.** See the section below.
+
+---
+
+## Implementation checklist — every site that binds, assigns, or infers a type
+
+This is the exhaustive enumeration for the team enforcing the rule. Ticks are
+what the code does **today**.
+
+### A. Statement-level binding sites
+
+| # | site | source | analyzer | codegen | notes for enforcement |
+|---|---|---|---|---|---|
+| A1 | `VarDecl` with a declared type | `analyzer:1987-2009`, `codegen:2696-2716` | ✅ sets | ✅ sets | the canonical declaration; the rule's anchor point |
+| A2 | **`VarDecl` with `var_type: None`** (`Set`/`Store`/`Assign`/`Create`) | `parser:944`, `:972`, `:1453` | ❌ none | ❌ none | **findings 1, 13, 16.** Highest-priority site |
+| A3 | `Assignment` (`X is v`, `the X is v`) | `analyzer:2047-2089`, `codegen:2912-2933` | ✅ sets/clears | ✅ sets, no-ops on `Unknown` | the obvious site; the one everyone will patch |
+| A4 | `FlagSchemaDecl` | `analyzer:2012-2041`, `codegen:2879-2905` | ✅ checks default | ✅ sets from `FlagValueType` | already type-checks its default |
+| A5 | **`ParseFlags`** | `codegen:2907-2910` | ❌ no-op | ❌ **no-op placeholder** | flags are **never parsed at runtime**; becomes a binding site when implemented |
+| A6 | `ForRange` loop variable | `analyzer:2151`, `codegen:3032-3069` | ✅ `Integer` | ❌ **nothing** | **finding 2** |
+| A7 | `ForEach` loop variable | `analyzer:2167`, `codegen:3520` / `:3410` | ⚠️ clears | ✅ elem type / `String` | **finding 18**; see Mixed discussion |
+| A8 | `Repeat` counter | `codegen:3078` | n/a | n/a | counter is internal `_repeat_counter`, **not user-bindable** — no burden |
+| A9 | Function parameters | `analyzer:2330`, `codegen:3261` | ✅ + save/restore `2299`/`2349` | ✅ + save/restore `3219`/`3379` | **verified correct**, no leak across functions |
+| A10 | `Allocate` | `analyzer:2214`, codegen arm | ✅ clears | ❌ **nothing** | **finding 17** |
+| A11 | `Free` | analyzer/codegen | ❌ leaves type | ❌ leaves type | name keeps its type after the memory is gone |
+| A12 | `BufferDecl` | `codegen:3587` | ✅ `buffer_variables` | ✅ `Buffer` | |
+| A13 | `FileOpen` | `analyzer:2563-2569`, `codegen:3974+` | ⚠️ `file_variables` only | ❌ **nothing** | **finding 3** |
+| A14 | `FileRead` / `FileReadLine` | analyzer/codegen | ✅ requires buffer | ✅ | writes *through* a buffer |
+| A15 | `TimerDecl` | `codegen:4689` | ✅ | ✅ `Integer` | the `// Track as integer for now` comment is **benign** |
+| A16 | `GetTime` | `analyzer:2802`, `codegen:4732` | ✅ `Integer` | ✅ `Integer` | correct on both sides |
+| A17 | `ByteSet` / `ElementSet` / `MapSet` / `ListAppend` / `BufferCopy` / `BufferClear` / `BufferResize` | various | write *through* | write *through* | `MapSet`/`ListAppend` store back a **reallocated pointer** (`ast.rs:416-429`) — the slot is rewritten even though the type does not change |
+| A18 | `Return` / declared return type | `parser:4282-4318` | ✅ | ✅ `function_return_types` | a top-level `Return` **ends the function body** (`parser:4318-4327`) — intended |
+
+### B. Expression-level type-inference sites
+
+Everything that answers "what type is this value" — `arithmetic_operand_type`
+and `infer_simple_expr_type` (analyzer), `infer_expr_type` (codegen).
+
+| site | today | notes |
+|---|---|---|
+| **`MapAccess`** | ❌ always `Unknown` | `Type::Map(Box::new(Type::Unknown))` at `analyzer:1315`, `1547`, `1761`, `1768`. **Findings 4, 14.** No map anywhere is given a value type |
+| `ElementAccess` / `ListAccess` | ✅ via `list_element_types`, `Mixed` when heterogeneous | |
+| `ByteAccess` | ✅ integer | verified |
+| `FunctionCall` | ✅ via `function_return_types` | verified: `n is mk.` retypes correctly |
+| `Argument*` (`ArgumentAt/Name/First/Second/Last`) | ✅ `String` at `codegen:2760-2766` | in the **`VarDecl`** path |
+| `ArgumentAll` / `ArgumentRaw` | ✅ `List` of `String` at `codegen:2755-2757` | |
+| `EnvironmentVariable*` | ✅ `String` at `codegen:2760-2766` | same arm as `Argument*` |
+| `Cast` / `TreatingAs` | ✅ | **the escape hatch the whole rule depends on** — `'42' as a number` |
+| `FormatString` | ✅ `String`; buffer destination required (`analyzer:2056`) | |
+| `BinaryOp` / `UnaryOp` / `Range` / `ListLit` / `MapLit` | ✅ | |
+| `LastError`, `CurrentTime`, `Fork`, `ReapChild`, `FileAvailable`, `DurationCast`, `NothingLit`, `PropertyAccess`, `PropertyCheck`, `TypeCheck` | mixed | statically typed; no retype surface found |
+
+### C. Cross-module and scope machinery
+
+| site | source | notes |
+|---|---|---|
+| **`.lib` imported signatures** | `src/lib_file.rs:194-201`, `:252` | parses declared parameter and return types (`Integer/String/Boolean/File/Value/Buffer/List/Map`) and feeds both `analyzer.imports` and `codegen.imports`. **The importing program trusts the `.lib`'s declared types with no verification against the `.so`** — a binding site across a module boundary |
+| `collect_definite_decls` | `ast.rs:642-681` | shared analyzer/codegen view of which main-line declarations act as globals. Carries `DefiniteDeclKind` (Plain/Buffer/List/Map/File) — a *kind*, **not a scalar type**, so the global-mirror path has no opinion on number-vs-text |
+| global bss mirrors | `emit_mirror_stack_var_to_global_if_needed` | globals get a mirror slot; type comes from `variable_types` |
+| `If` branch merge | `analyzer:2091-2136` | merges **availability only**; types are not part of `AnalysisEnv` — the root of findings 6-11 |
+| function scope save/restore | `analyzer:2299`/`2349`, `codegen:3219`/`3379` | ✅ correct |
+| **nested block shadowing** | — | ❌ no separate slot, outer clobbered, no restore — **finding 12** |
+| loop variable after loop exit | — | persists with the last iteration's value and type |
+
+### D. The runtime-tag (dynamic) machinery
+
+| component | source |
+|---|---|
+| `mixed_lists` — pre-scan set of heterogeneous lists | `codegen:20` |
+| `list_element_types` → `VarType::Mixed` | `codegen:15` |
+| `mixed_tag_slots` — shadow slot holding the runtime tag | `codegen:31` |
+| `value_typed_names` — declared `value`; bare arithmetic rejected | `analyzer:1969-1974` |
+| `unprovable_scalars` | `codegen:27` |
+| `Type::Value` / `VarType::Mixed` | `ast.rs`, `codegen` |
+
+### E. Sites the brief did not list — what I found beyond it
+
+The steer asked specifically for anything not on its list. These are the ones:
+
+1. **`ParseFlags` is an unimplemented no-op** (A5). Flag values are never
+   parsed at runtime, so `FlagSchemaDecl`'s declared type is currently never
+   challenged by a real value. When runtime parsing lands it becomes a binding
+   site that converts text argv into typed values — a natural home for the
+   same class of bug.
+2. **`Free` does not clear tracking** (A11). The name keeps its type after the
+   memory is gone. Independently, `Allocate` + `Free` + use segfaults today
+   (use-after-free, noted under "adjacent" below).
+3. **Map value types are structurally unknowable** (B). Not merely un-inferred
+   in one path — `Type::Map` is *only ever* constructed with
+   `Box::new(Type::Unknown)`, at all four sites. Even a homogeneous map
+   literal like `{"k": 42}` yields no value type.
+4. **`Repeat` counters are not user-bindable** (A8) — one *fewer* site than
+   the steer expected; the counter is an internal `_repeat_counter` slot.
+5. **Tuples, multiple return values and destructuring do not exist yet.**
+   `Type` has no tuple variant, `Expr` has none, and
+   `grep -rn "Tuple\|destructur" src/` returns nothing. Plans 110/120/130
+   specify them but have not landed. **The rule should be settled before they
+   do**, because destructuring binds several names at once and is a binding
+   site by construction.
+6. **`.lib` signatures are trusted, unverified** (C). Nothing checks the
+   declared types in a `.lib` against the actual `.so`.
+7. **`collect_definite_decls` carries kind, not type** (C).
+8. **Loop variables outlive their loop** (C), keeping the last iteration's
+   value — so their type after the loop is a real question, not a hypothetical.
+
+---
+
+## Enforcing the rule per site — and where a fixed type is the *wrong* answer
+
+### What enforcement requires, by group
+
+**The binding sites (A2, A6, A10, A13 — findings 1, 2, 3, 17).** These are the
+"survives" column and the real work. Each stores a new runtime value into an
+existing name without going through `Statement::Assignment`. Enforcement must
+decide, per site, between *reject* (the name is already declared with a
+different type) and *rebind* (this is a new declaration that shadows). Because
+this is a class of **omission**, patching the four known sites will not stop
+the fifth appearing: the durable shape is a single choke point — one
+`bind(name, type, span)` helper that every arm must call, so forgetting is a
+visible absence rather than a silent default. That helper is also the natural
+place to raise the new diagnostic.
+
+**The assignment site (A3) plus the `VarDecl{None}` path (A2).** The cleanest
+shape is for the parser to emit `Statement::Assignment` when the name is
+already declared and no type is written, so there is one path to keep correct
+instead of two. Adding a parallel check to the `VarDecl` arms leaves
+`VarDecl{None}` as a live trap for the next statement form that reuses it.
+
+**Operations that ignore the type (findings 5, 15).** Independent of the rule
+and cheap: `Increment`/`Decrement` should reject a non-numeric target, reusing
+the existing arithmetic diagnostic. This can land first and is a strict
+improvement regardless of what happens to the rest.
+
+**Scope (finding 12).** Decide whether an inner declaration shadows or is an
+error. If it shadows, it needs its own slot and a restore at scope exit; the
+function-scope save/restore at `analyzer:2299`/`2349` and
+`codegen:3219`/`3379` is the working model to copy.
+
+**Flow-sensitivity (findings 6-11).** Becomes unnecessary for type tracking
+once the rule holds, and that is a large simplification: it removes the need
+for the per-branch snapshot/merge that plan 293 recommends. Keep the existing
+`AnalysisEnv` merge for variable *availability*, which is a separate concern
+and already correct.
+
+### Where a fixed type is genuinely the wrong answer
+
+**1. For-each over a heterogeneous list — the case to get right (finding 18).**
+
+The loop variable genuinely holds a different type each iteration. No fixed
+type is correct: pinning it to the first element's type is wrong for every
+other element, and pinning it to text/number rejects valid programs. This is
+precisely what `Type::Value`/`VarType::Mixed` exists for, and **the compiler
+already computes the discriminator it needs** — the `mixed_lists` pre-scan
+proves whether a list is heterogeneous before codegen runs.
+
+The correct design falls out of that:
+
+- **Homogeneous list** → the element type is known, the loop variable takes it
+  as a normal fixed type. This is already what `codegen:3520` does.
+- **Heterogeneous list** → the loop variable is `value`/Mixed. Printing
+  already dispatches on the runtime tag and is correct today. What is missing
+  is that **arithmetic and other type-specific operations must require a check
+  or a cast**, exactly as a declared `a value called x` already does.
+
+The mechanism is already built and working. Verified:
+
+```vox
+a value called v is 5.
+a number called z is v add 1.
+```
+
+gives `Cannot use a value v in arithmetic; check its type with 'is a number'/'is a text' first.`
+
+So the fix for finding 18 is not new machinery — it is to route
+heterogeneous-list loop variables into `value_typed_names`
+(`analyzer:1969-1974`) instead of merely *clearing* their label at
+`analyzer:2167`. Clearing says "I don't know, allow anything"; the rule needs
+"I don't know, so demand a check". **That one-word difference in intent is the
+whole finding.**
+
+**2. Map reads (findings 4, 14).** Because map value types are never inferred,
+every map read is dynamically typed in practice. Two coherent options:
+
+- *Infer value types for homogeneous map literals* (`{"k": 42}` → map of
+  number), which makes the rule enforceable and closes findings 4 and 14 by
+  making the mismatch visible; or
+- *Treat every map read as `value`*, requiring a check or cast at the use
+  site — sound, consistent with option 1's fallback for heterogeneous maps,
+  but more verbose for the common homogeneous case.
+
+Doing neither leaves findings 4 and 14 alive **and silent**, which is the
+worst outcome: the rule would appear to close them while the segfault remains.
+I recommend inferring for homogeneous literals and falling back to `value`,
+which mirrors how lists are already handled and reuses the same pre-scan idea.
+
+**3. Externally-sourced values.** `Argument*`, `EnvironmentVariable*` and
+`LastError` have known static types (`String`/`Integer`), so a fixed type is
+correct. `ParseFlags` (A5), when implemented, converts text argv into the
+flag's declared type — a cast, not a retype, so it fits the rule cleanly.
+
+**4. `.lib` imports.** Declared types cross the module boundary unverified. A
+fixed-type rule is only as strong as the weakest declaration it trusts; worth
+deciding whether a mismatch between `.lib` and `.so` should be detectable.
+
+---
+
+## Migration cost
+
+**One site in one file.** The rule is cheap to adopt.
+
+```bash
+python3 migration_scan.py tests examples     # script in the audit scratch dir
+```
+
+The scan classifies literal right-hand sides only: it walks each `.vox` file,
+records `a <type> called <name>` declarations, then flags any
+`X is <literal>` / `the X is <literal>` / `Set|Store|Assign|Create X to
+<literal>` whose literal kind differs from the declared type. Buffers, lists,
+maps and `value` are exempt.
+
+```
+files scanned : 354      (324 under tests/, 30 under examples/)
+files affected: 1        (excluding this audit's own PoC files)
+retype sites  : 1
+```
+
+The single hit is `tests/149_cast_in_arithmetic.vox:25`:
+
+```vox
+a text called dyn is "hi".
+dyn is 5.
+a number called dynr is dyn add 1.
+```
+
+Note this test **deliberately asserts that implicit retyping works** — its
+`.expected` ends in `6`, which is `dyn add 1` after the retype. So migration
+here is not "add a cast": it is amending a test that encodes the old
+semantics. That is the only such test in the corpus.
+
+**Confidence and limits.** The heuristic under-counts by construction: a
+retype whose right-hand side is a function result, a map read or an element
+read is invisible to it, and those are exactly findings 4/14/18. It is a lower
+bound, not a proof. Three things suggest the true number is still small: the
+corpus contains 368 typed declarations and 274 `Set`/`Store`/`Assign`
+statements, of which **164 are `set byte …`** (`ByteSet`, not a variable
+binding) and a further handful are `set element`/`set …'s` (`ElementSet`,
+`MapSet`); and the only two files matching `set X to "…"` are
+`tests/066_format_buffer_set_append_copy.vox` and
+`tests/067_format_buffer_fixed_overflow.vox`, where the targets are **buffers**
+(format-string writes, already special-cased at `analyzer:2074` and
+`codegen:2919`/`2935`) and therefore exempt.
+
+**Order of magnitude: single digits.** The rule does not need adjusting on
+migration-cost grounds.
+
+---
+
+## Null results — constructs checked and found correct
+
+Each was run the same way: write the program to `p.vox` in a temp directory
+(never the repo — a compiled Vox program is dropped in the CWD), then
+
+```bash
+cd "$(mktemp -d)" && vox p.vox -o p.bin && ./p.bin; echo "exit=$?"
+```
+
+| construct | program | observed | verdict |
+|---|---|---|---|
+| plain assignment `X is <text>` over a number | `a number called n is 5.` / `n is "abc".` | `abc` | correct today — **the rule repeals this** |
+| plain assignment `X is <number>` over text | `a text called s is "hello".` / `s is 5.` | `5` | correct today — likewise |
+| `the X is <value>` | `the n is "abc".` | `abc` | correct — parses to `Statement::Assignment` (`parser:1808`) |
+| assignment from a function return value | `To mk. Return a text, "abc".` / `n is mk.` | `abc` | correct |
+| assignment from a list element | `a list called L is ["abc","def"].` / `n is element 1 of L.` | `abc` | correct — elements are runtime-tagged |
+| assignment from a buffer byte | `s is byte 1 of b.` over a text `s` | `0` | correct — retypes to integer |
+| `Set element N of L to <text>` on a numeric list | `Set element 1 of L to "abc".` | `["abc", 2, 3]` | correct — `ElementSet` writes a tagged element |
+| **print** of a for-each variable over a heterogeneous list | `[42, "hello", 3.14]` | `42 / hello / 3.14` | correct — dispatches on the runtime tag (contrast finding 18) |
+| `Get current time into X` over a text name | over `a text called t` | `1786204206` | correct — both maps retype (`analyzer:2802`, `codegen:4732`) |
+| `Create a timer called X` over a text name | over `a text called clock` | `0` | correct — `codegen:4689` retypes to integer |
+| function parameter typing does not leak out | `To f with a number called v.` + a global text `v` | `3` then `hello` | correct — save/restore both sides |
+| same parameter name, two functions, different types | `To f with a number called p.` + `To g with a text called p.` | `f 7` / `g hi` | correct — no cross-function leak |
+| `a value called v` rejects bare arithmetic | `a number called z is v add 1.` | compile error naming the check | correct — **the mechanism finding 18 should reuse** |
+| dead code after a top-level `Return` | `To f.` / `Return a number, 1.` / `n is "abc".` | `abc` | **correct, and intended** — see below |
+
+### Two things that look like bugs and are not
+
+**A top-level `Return` ends the function body.** `To f. Return a number, 1.
+n is "abc".` prints `abc` at top level even though `f` is never called. I
+initially recorded this as a finding; it is not one.
+`src/parser/mod.rs:4318-4327` documents the behaviour explicitly, so
+`n is "abc".` is a genuine top-level statement. Confirmed directly: a
+`Print "SIDE EFFECT".` before the `Return` never runs, while a
+`Print "LEAKED".` after it prints in top-level order. Consequently the brief's
+"early `Return`" item has no separate failure mode — a return inside a
+conditional reduces to the `If` case.
+
+**A block body is one statement unless clauses are comma-separated.**
+`For each item in data,` followed by two period-terminated `Print` lines runs
+only the first inside the loop; the second executes once afterwards with the
+loop variable's final value. This is the comma/period clause structure, not a
+bug — but it invalidates any test written with multi-statement
+period-separated bodies. It cost me two spurious results before I caught it
+(finding 18 is the corrected version), and it is worth knowing before writing
+regression tests for the fix. Every PoC in this audit uses a single-statement
+body or explicit comma clauses.
+
+---
+
+## Suspected, not reproduced
+
+- **Short-circuit evaluation.** Listed in the brief as a direction-1 path. No
+  repro is constructible because assignment is not an expression in Vox —
+  there is no way to place a store inside the right-hand operand of `and`/`or`.
+- **`MapSet` / `BufferCopy` retyping their target.** These write *through* a
+  variable; I found no way to make the container's own tracked type change.
+  `ElementSet` is confirmed correct. I did not find a defect, and I also
+  cannot prove absence — see "not audited".
+
+## Adjacent — real and reproducible, but not retype bugs
+
+- **A declaration inside a nested block clobbers the outer variable.** The
+  *taken*-branch form of finding 12. Tracked type and runtime value stay
+  consistent, so it is not memory-unsafe — it is the shadowing decision the
+  rule must make anyway.
+- **Use-after-free.** `Allocate 32 for s.` / `Free s.` / `Print "[{s}]".`
+  segfaults. Independent of type tracking; correct types would still
+  dereference freed memory.
+
+## Root-cause grouping
+
+**Group A — flow-insensitive type tracking.** Findings 6-11. One defect, six
+surfaces. **Fully closed by the rule.**
+
+**Group B — re-declaration forms never retype.** Findings 1, 13, 16.
+`Set`/`Store`/`Assign`/`Create` produce `VarDecl { var_type: None }`; both
+consumers guard on `Some`. One missing update, three consequences: a segfault,
+wrong output, and a spurious compile error. **Closed by the rule only if
+enforced on that path.**
+
+**Group C — statements that rebind a name without retyping it.** Findings 2, 3,
+17 (and finding 12's slot reuse). Each is a separate statement arm.
+**Survives the rule.** The group the brief predicted would be largest, and the
+one where undiscovered instances are most likely.
+
+**Group D — untyped expression results leave stale tracking.** Findings 4, 14.
+`VarType::Unknown` is a deliberate no-op at `codegen:2931` while the analyzer
+correctly clears. **Survives the rule** until map value types are inferred.
+
+**Group E — operations that ignore the tracked type.** Findings 5, 15, 18.
+Not tracking bugs at all: tracking is correct and the code generator does not
+consult it. **Survives the rule**, and is independent of it.
+
+Groups C, D and E are genuinely independent of each other and of the rule.
+Group A is one bug; group B is one bug with three faces.
+
+## Cross-cutting recommendation
+
+Findings 2 and 17 are codegen-only, and finding 2 is a case where the analyzer
+is *right* and codegen is wrong — so no diagnostic is possible even in
+principle. Two hand-maintained copies of the same information in two files
+guarantee a recurring supply of this bug class. The strategic fix is for the
+analyzer to publish a resolved per-variable type that codegen **reads** rather
+than recomputes. That is larger than any single fix here and should be a
+deliberate decision, but every group except E gets cheaper once it is done —
+and the type-immutability rule makes it markedly easier, because a type that
+never changes after declaration is far simpler to publish than one that varies
+per program point.
+
+## What I could not audit, and why
+
+- **`.lib` type agreement across a module boundary.** `src/lib_file.rs` has a
+  real type surface (`:194-201`, `:252`) but no `scalar_types`/`variable_types`
+  involvement — both maps are referenced only in `src/analyzer/mod.rs` and
+  `src/codegen/mod.rs`, zero references elsewhere in `src/`. I did **not** test
+  whether a `.lib` can declare a type that disagrees with its `.so`; that needs
+  a two-crate fixture. Genuine gap.
+- **`MapSet` and `BufferCopy` as retype vectors.** Probed, nothing found, but I
+  could not construct a case that changes the container's tracked type, so I
+  cannot distinguish "correct" from "wrong shape tried".
+- **Cross-function global retyping.** Parameters are properly scoped
+  (verified), but I did not get a reproduction for a function that assigns to a
+  *global* of a different type and is then called conditionally. The
+  save/restore at `analyzer:2299`/`2349` suggests the tracking write would be
+  discarded while the runtime write persists — a direction-2 bug — but I will
+  not report it as a finding without a repro.
+- **Non-x86_64 targets.** Everything here is x86_64; `coreasm/` was not
+  exercised. A target with a different string representation could change the
+  observed symptom, though not the tracking defect.
+- **Migration count is a lower bound**, per the limits stated in that section.
+
+## Notes on the brief
+
+The brief was accurate everywhere I checked it; the `scalar_types` and
+`variable_types` write-site line numbers were all correct. Three refinements:
+
+1. `src/codegen/mod.rs:4689` (`// Track as integer for now`) was flagged as a
+   likely home for a wrong assumption. It is `TimerDecl`, and it is
+   **correct** — verified. The suspicious comment is benign.
+2. **Bug B deserves higher than "high".** The same missing update with the
+   operands swapped (finding 1) is a segfault, not wrong output.
+3. The brief's premise that "reassigning a number to text is legal Vox" is
+   true today and is what makes Bug B a bug rather than invalid code — and it
+   is exactly what the new rule repeals. Under the rule, Bug B's repro program
+   becomes a compile error and the finding is closed by redefinition rather
+   than by fixing the tracking.

--- a/docs/plans/294_retype_audit.md
+++ b/docs/plans/294_retype_audit.md
@@ -439,6 +439,84 @@ is right for a homogeneous list and unsound for a heterogeneous one.
 > **Under the new rule:** **survives, and it is the case where a fixed type is
 > the wrong answer.** See the section below.
 
+### 21 — high — casting a dynamically-tagged `value` silently computes garbage
+
+Not in the original 18. Discovered mid-implementation, while verifying that
+finding 18's fix (routing a heterogeneous-list loop variable into
+`value_typed_names`) actually has a working escape hatch — a review asked for
+end-to-end proof that the fix-it hint the compiler prints is not itself a
+dead end, and running it revealed this.
+
+```vox
+a map called m is {"k": "hello"}.
+a value called v is m's "k".
+a number called z is v as a number.
+Print "z={z}".
+```
+
+Observed `z=4198548` (the string's address); expected `z=0` (`atoi("hello")`,
+matching the language's established behaviour for parsing a non-numeric
+string — see the Type Casting table). Confirmed reproducing on unmodified
+`main` (`409bd2c`) — pre-existing, unrelated to plans 290-293 or this
+track's own commits (`git diff 409bd2c -- src/codegen/mod.rs` was empty at
+the moment this was found).
+
+**Root cause.** `Expr::Cast`'s codegen (`src/codegen/mod.rs`, the
+`Expr::Cast { value, target_type, radix }` arm) dispatches on the STATIC
+source type from `infer_expr_type`. For a `value`-typed source that type is
+always `VarType::Mixed`, and every target-type branch's fallback for a
+source type it doesn't specifically recognise is to pass the raw payload
+through unconverted rather than convert it. That is silently correct only
+when the runtime tag happens to already match the target's native
+representation (an Integer-tagged `value` cast `as a number` is a no-op that
+*looks* like a real conversion, because none was needed) and silently wrong
+for every other tag — here, a text pointer reinterpreted as an integer. This
+is the exact bug family the whole track exists to close, reached through the
+fix-it hint the compiler itself was recommending (`Cannot use a value v in
+arithmetic; check its type... first` before this track, or the equivalent
+cast-based hint mid-track) rather than around it.
+
+The mechanism to fix this properly already exists and is proven correct for
+a different consumer: `Print` on a `value` dispatches on the runtime tag via
+`mixed_tag_slots` and `emit_mixed_print_dispatch`, which is exactly the
+shape a `emit_mixed_cast_dispatch` would need (read the tag, branch, and in
+each branch do what the existing static-source Cast logic already does for
+that source type). Estimated as real but non-trivial: up to 4 source tags ×
+4 target types, each branch needing correct register/stack discipline,
+reusing existing runtime helpers (`_parse_i64`, `_parse_f64`, the boolean/
+text conversions already in the static-source branches) rather than
+reimplementing them.
+
+**Decision made under this track:** reject the cast instead of implementing
+the dispatch. Two reasons: implementing it correctly is real codegen work in
+exactly the highest-risk area for a change like that to go wrong under time
+pressure (a mistake here reintroduces the same class of memory-unsafety this
+whole track exists to close), and rejecting is unconditionally safe — it can
+only ever be *more* permissive later, once the dispatch is actually built,
+never require walking back a guarantee. The rejection message deliberately
+names no workaround: the type-predicate guard (`is a number`/`is a text`)
+does not narrow the type inside its own body either (verified directly, not
+assumed), so recommending it would repeat the exact mistake this finding is
+about — pointing confidently at a dead end.
+
+**Cost estimate for the real fix**, for whoever picks this up: a new
+`emit_mixed_cast_dispatch(tag_slot, target_type, radix)` in
+`src/codegen/mod.rs`, modelled directly on `emit_mixed_print_dispatch`
+(same file). Wire it into the `Expr::Cast` arm wherever `value` is an
+`Expr::Identifier`/`Expr::StringLit` with a `mixed_tag_slots` entry, ahead of
+the existing static-source branches. The individual conversions per
+source-tag/target-type pair are not new — they already exist in the
+static-source branches this arm has today — the work is extracting them into
+tag-dispatched branches and testing the full matrix (a same-tag no-op path,
+and each real conversion, for each of the 4 tags × 4 targets). Once done,
+this repro should print `z=0` and `poc.sh` should flip to non-zero.
+
+> **Under the new rule:** the silent-garbage direction is closed (this repro
+> is now a compile error). The conversion itself remains unimplemented -
+> tracked here as its own follow-up, not attempted in this track.
+
+PoC: `tests/retype_audit_pocs/21-dynamic-value-cast-silent-garbage/`.
+
 ---
 
 ## Implementation checklist — every site that binds, assigns, or infers a type

--- a/src/analyzer/mod.rs
+++ b/src/analyzer/mod.rs
@@ -595,6 +595,17 @@ pub struct Analyzer {
     /// without an explicit type check (stage 1c predicate); the arithmetic
     /// operand check uses this set to reject unguarded use with a clear error.
     value_typed_names: HashSet<String>,
+    /// Lists proven heterogeneous from their own literal initializer at
+    /// declaration time (plan 294 finding 18) - e.g. `a list called data is
+    /// [42, "hello"].`. Deliberately narrower than codegen's `mixed_lists`
+    /// pre-scan: this only looks at a direct `ListLit` initializer, not
+    /// aliasing through other variables or widening via later `Append`s.
+    /// That asymmetry is safe in the direction it's used (a `for each` loop
+    /// variable over a list this set doesn't catch keeps today's existing,
+    /// unchanged behaviour rather than being wrongly tightened), but it
+    /// means a list built up entirely through `Append` calls of differing
+    /// types is not detected as mixed here the way it would be by codegen.
+    list_mixed: HashSet<String>,
     loop_depth: usize,
     /// True when compiling `--shared`. A shared library has no `_start`, so a
     /// top-level executable statement would be generated into the discarded
@@ -685,6 +696,7 @@ impl Analyzer {
             scalar_types: HashMap::new(),
             function_param_counts: HashMap::new(),
             value_typed_names: HashSet::new(),
+            list_mixed: HashSet::new(),
             loop_depth: 0,
             shared_mode: false,
             current_library: None,
@@ -1811,8 +1823,22 @@ impl Analyzer {
             Type::Map(_) => format!("Cannot use map {} in arithmetic.", label),
             Type::File => format!("Cannot use file {} in arithmetic.", label),
             Type::Timer => format!("Cannot use timer {} in arithmetic.", label),
+            // Deliberately NOT "check its type with 'is a number' first":
+            // verified that guard does not narrow the type inside its own
+            // body, so the advice would be a dead end (still rejected
+            // after doing exactly what it says). `as a number`/`as text`
+            // is the escape hatch that LANGUAGE.md documents and that
+            // actually compiles - though it's only proven correct here
+            // when the value's tag is statically known; a value whose tag
+            // is genuinely only known at runtime (e.g. from a map read, or
+            // plan 294 finding 18's heterogeneous-list loop variable) casts
+            // without error but silently reads the wrong bytes - a
+            // separate, pre-existing codegen gap (confirmed on unmodified
+            // `main`, unrelated to this track) in Cast not consulting the
+            // runtime tag. Recording that here rather than in a hint
+            // string a `.err` fixture would have to pin.
             Type::Value => format!(
-                "Cannot use a value {} in arithmetic; check its type with 'is a number'/'is a text' first.",
+                "Cannot use a value {} in arithmetic; convert it explicitly first with 'as a number' or 'as text'.",
                 label
             ),
             _ => return,
@@ -1954,6 +1980,41 @@ impl Analyzer {
                 | (Type::List(_), Type::List(_))
                 | (Type::Map(_), Type::Map(_))
         )
+    }
+
+    /// Classify a list-literal element for the finding-18 homogeneity
+    /// check. `None` means "can't prove a single tag" (an identifier,
+    /// function call, property/element access, `nothing`, ...) and is
+    /// treated as mixed by the caller - matching codegen's own
+    /// `TagInfo::Unknowable` policy of widening to mixed rather than
+    /// guessing when a value's tag can't be proven statically.
+    fn list_element_kind(&self, expr: &Expr) -> Option<Type> {
+        match expr {
+            Expr::StringLit(_) => Some(Type::String),
+            Expr::IntegerLit(_) => Some(Type::Integer),
+            Expr::FloatLit(_) => Some(Type::Float),
+            Expr::BoolLit(_) => Some(Type::Boolean),
+            Expr::ListLit { .. } => Some(Type::List(Box::new(Type::Unknown))),
+            Expr::MapLit { .. } => Some(Type::Map(Box::new(Type::Unknown))),
+            _ => None,
+        }
+    }
+
+    /// True iff a list literal's elements don't all share one provable
+    /// type - see `list_element_kind` and `list_mixed`.
+    fn list_literal_is_mixed(&self, elements: &[Expr]) -> bool {
+        let mut seen: Option<Type> = None;
+        for e in elements {
+            let Some(t) = self.list_element_kind(e) else {
+                return true;
+            };
+            match &seen {
+                None => seen = Some(t),
+                Some(prev) if !self.treating_types_compatible(prev, &t) => return true,
+                Some(_) => {}
+            }
+        }
+        false
     }
 
     fn type_name(&self, ty: &Type) -> &'static str {
@@ -2364,6 +2425,15 @@ impl Analyzer {
                 }
                 if let Some(Type::List(_)) = var_type {
                     self.list_variables.insert(name.clone());
+                    // Plan 294 finding 18: a `for each` loop variable over
+                    // a list this proves heterogeneous must be dynamically
+                    // typed (see the ForEach arm) rather than silently
+                    // allowing arithmetic that only some elements support.
+                    if let Some(Expr::ListLit { elements }) = value {
+                        if self.list_literal_is_mixed(elements) {
+                            self.list_mixed.insert(name.clone());
+                        }
+                    }
                 }
                 if let Some(Type::Map(_)) = var_type {
                     self.map_variables.insert(name.clone());
@@ -2623,6 +2693,31 @@ impl Analyzer {
                 // list - must not linger and falsely reject arithmetic on the
                 // loop variable inside the body.
                 self.scalar_types.remove(variable);
+                // Plan 294 finding 18: over a list PROVEN heterogeneous (see
+                // `list_mixed`/`list_literal_is_mixed`), the loop variable
+                // genuinely holds a different type each iteration - no
+                // fixed type is correct, so route it into the same
+                // dynamic/`value` mechanism a declared `a value called x`
+                // uses, demanding an explicit check before arithmetic
+                // instead of silently allowing it on whatever type the
+                // element turns out not to be. A list this narrower,
+                // single-pass check can't prove mixed (see `list_mixed`'s
+                // own doc comment on what it does not catch) keeps today's
+                // existing behaviour unchanged.
+                let list_name = match collection {
+                    Expr::Identifier(n) | Expr::StringLit(n) => Some(n.as_str()),
+                    _ => None,
+                };
+                let is_mixed = match (list_name, collection) {
+                    (Some(n), _) => self.list_mixed.contains(n),
+                    (None, Expr::ListLit { elements }) => self.list_literal_is_mixed(elements),
+                    (None, _) => false,
+                };
+                if is_mixed {
+                    self.value_typed_names.insert(variable.clone());
+                } else {
+                    self.value_typed_names.remove(variable.as_str());
+                }
                 self.analyze_expr(collection);
                 self.loop_depth += 1;
                 for s in body {

--- a/src/analyzer/mod.rs
+++ b/src/analyzer/mod.rs
@@ -606,6 +606,20 @@ pub struct Analyzer {
     /// means a list built up entirely through `Append` calls of differing
     /// types is not detected as mixed here the way it would be by codegen.
     list_mixed: HashSet<String>,
+    /// A map's value type, proven from its own literal initializer when
+    /// every value shares one provable type (plan 294 findings 4, 14) -
+    /// e.g. `{"k": 42}` is a map of number. `Type::Map` is otherwise never
+    /// given a value type anywhere in the analyzer, so a mismatched read
+    /// (`a text called s is m's "k".` where `m`'s values are numbers) was
+    /// unprovable and silently passed the type lock. Absent (not `None`
+    /// stored, just no entry) for a map whose literal has mixed value
+    /// types, an empty map, or a non-literal initializer - `arithmetic_
+    /// operand_type` then returns `None` for a read from it, same
+    /// "can't prove it, so allow" policy as everywhere else in this file.
+    /// Narrower than a full type system: only the map's own declaration
+    /// site is consulted, not aliasing or later `Set <map>'s "k" to
+    /// <value>` writes that could widen it.
+    map_value_type: HashMap<String, Type>,
     loop_depth: usize,
     /// True when compiling `--shared`. A shared library has no `_start`, so a
     /// top-level executable statement would be generated into the discarded
@@ -697,6 +711,7 @@ impl Analyzer {
             function_param_counts: HashMap::new(),
             value_typed_names: HashSet::new(),
             list_mixed: HashSet::new(),
+            map_value_type: HashMap::new(),
             loop_depth: 0,
             shared_mode: false,
             current_library: None,
@@ -1765,6 +1780,13 @@ impl Analyzer {
                     }
                 }
             },
+            // Plan 294 findings 4, 14: only resolvable when the map's own
+            // literal initializer proved a single value type (see
+            // `map_value_type`) - a map declared with a non-literal
+            // initializer, an empty literal, or a literal with mixed value
+            // types falls through to `None`, same "can't prove it, allow
+            // it" policy as everywhere else in this function.
+            Expr::MapAccess { map, .. } => self.map_value_type.get(map).cloned(),
             _ => None,
         }
     }
@@ -2015,6 +2037,24 @@ impl Analyzer {
             }
         }
         false
+    }
+
+    /// The single provable value type shared by every pair in a map
+    /// literal (keys are always text and don't factor in), or `None` for
+    /// an empty map, a mixed one, or a value that isn't a simple literal.
+    /// See `map_value_type`'s doc comment for how this is used and its
+    /// limits.
+    fn map_literal_value_type(&self, pairs: &[(Expr, Expr)]) -> Option<Type> {
+        let mut seen: Option<Type> = None;
+        for (_, v) in pairs {
+            let t = self.list_element_kind(v)?;
+            match &seen {
+                None => seen = Some(t),
+                Some(prev) if !self.treating_types_compatible(prev, &t) => return None,
+                Some(_) => {}
+            }
+        }
+        seen
     }
 
     fn type_name(&self, ty: &Type) -> &'static str {
@@ -2437,6 +2477,15 @@ impl Analyzer {
                 }
                 if let Some(Type::Map(_)) = var_type {
                     self.map_variables.insert(name.clone());
+                    // Plan 294 findings 4, 14: a homogeneous map literal's
+                    // value type is provable, which makes a mismatched read
+                    // from it a statically-detectable type-lock violation
+                    // instead of a silently-allowed "can't prove it" case.
+                    if let Some(Expr::MapLit { pairs }) = value {
+                        if let Some(t) = self.map_literal_value_type(pairs) {
+                            self.map_value_type.insert(name.clone(), t);
+                        }
+                    }
                 }
                 if let Some(Type::Value) = var_type {
                     // A declared `a value called x` is dynamic, like a value
@@ -3803,11 +3852,64 @@ impl Analyzer {
                 self.analyze_expr(value);
             }
 
-            Expr::Cast { value, .. } => {
+            Expr::Cast { value, target_type, .. } => {
                 // Recurse so unknown variables / nested type errors inside
                 // a cast (`missing as a number`) are reported instead of
                 // compiling silently and emitting garbage.
                 self.analyze_expr(value);
+
+                // Plan 294 finding 21 (adjacent discovery, not one of the
+                // original 18): a cast on a dynamically-tagged `value`
+                // source (a declared `a value called x`, a `value`
+                // parameter, or - as of finding 18's fix - a heterogeneous-
+                // list loop variable) is codegen-unimplemented, not merely
+                // unchecked. Verified on unmodified `main`: codegen's Cast
+                // arm dispatches on the STATIC source type
+                // (`infer_expr_type`), which is `VarType::Mixed` here, and
+                // every target-type branch's fallback for an unrecognised
+                // source type is to pass the raw payload through
+                // unconverted. That is silently correct only when the
+                // runtime tag happens to already match the target's native
+                // representation (an Integer-tagged value cast `as a
+                // number` is a no-op that looks like a real conversion);
+                // for any other tag it reinterprets the bytes - a text
+                // pointer read as an integer, the same failure mode this
+                // whole track exists to close, just reached through the
+                // suggested fix-it rather than around it. The properly
+                // general fix is a runtime tag dispatch in codegen's Cast
+                // arm (the tag-branch machinery already exists and is
+                // proven correct for `Print`'s equivalent dispatch,
+                // `emit_mixed_print_dispatch`) - tracked as its own follow-
+                // up rather than attempted here under this session's time
+                // pressure, in the single highest-risk area for a change
+                // like that to go wrong. Loud and honest beats silently
+                // wrong: reject the cast instead of emitting it.
+                let is_dynamic_source = match value.as_ref() {
+                    Expr::Identifier(name) | Expr::StringLit(name) => {
+                        self.value_typed_names.contains(name.as_str())
+                    }
+                    _ => false,
+                };
+                if is_dynamic_source {
+                    // Deliberately not suggesting a workaround: the type
+                    // predicate guard ('X is a number') was checked and
+                    // does NOT narrow X's type inside its own body (still
+                    // rejected there too), so recommending it here would
+                    // repeat the exact mistake this whole check exists to
+                    // avoid - confidently pointing at a dead end. There is
+                    // currently no supported way to convert a genuinely
+                    // dynamically-tagged value; say so plainly rather than
+                    // invent one.
+                    self.push_error(
+                        format!(
+                            "Cannot cast {} to {}: {}'s type is only known at runtime, and casting a dynamically-tagged value is not currently supported by the compiler (a known gap, not yet resolvable from within the language).",
+                            self.operand_label(value),
+                            self.typed_phrase(target_type),
+                            self.operand_label(value),
+                        ),
+                        None,
+                    );
+                }
             }
 
             Expr::FileAvailable { path } => {

--- a/src/analyzer/mod.rs
+++ b/src/analyzer/mod.rs
@@ -2314,7 +2314,41 @@ impl Analyzer {
                 // lock applies to; a genuinely new `x` is a real
                 // declaration and must infer/lock its type as usual.
                 let was_already_declared = self.is_variable_available(name);
+                // A second explicitly-typed declaration of an
+                // already-declared name is a redeclaration, not scoping:
+                // Vox has no block-level lexical scoping today - If/While/
+                // etc. bodies share the enclosing scope's slots, so there
+                // is no separate slot for an inner declaration to occupy
+                // and no scope exit to restore the outer type at. Without
+                // this check, `a text called n is "abc".` inside an
+                // untaken `If` branch permanently overwrote the outer
+                // `number` n's tracked type regardless of whether the
+                // branch ever ran (plan 294 finding 12 - this is the
+                // declaration-arm counterpart to what the type lock
+                // already does for reassignment). A conflicting rebind is
+                // rejected exactly like `Statement::Assignment`/`Set`
+                // reusing an incompatible name; a same-type redeclaration
+                // (or a genuinely new name) is unaffected - `bind_variable_
+                // type` no-ops on either.
+                let redeclaration_conflict = if let (true, Some(vt)) = (was_already_declared, var_type.as_ref()) {
+                    self.bind_variable_type(
+                        name,
+                        vt.clone(),
+                        "this declaration",
+                        "declares as",
+                        &[format!("called {} ", name)],
+                        false,
+                    )
+                } else {
+                    false
+                };
                 self.declare_variable_in_current_scope(name);
+                if redeclaration_conflict {
+                    if let Some(v) = value {
+                        self.analyze_expr(v);
+                    }
+                    return;
+                }
                 // Register the declared type in the type-specific sets,
                 // mirroring the top-level pre-pass. That pre-pass only
                 // walks program.statements and never descends into
@@ -2804,7 +2838,6 @@ impl Analyzer {
                     || self.flag_variables.contains(name.as_str())
                     || self.timer_variables.contains(name.as_str())
                     || matches!(self.named_value_type(name), Some(Type::String))
-                    || self.value_typed_names.contains(name.as_str())
                 {
                     // Increment/Decrement compile to an integer `inc/dec
                     // qword` on the variable's stack slot. Applied to a
@@ -2820,11 +2853,16 @@ impl Analyzer {
                     // really is text - so the lock doesn't see it (plan 294
                     // findings 5/15): the pointer just gets walked one byte
                     // at a time with no relationship to the string's bounds
-                    // until it wanders off the mapping. A `value`-typed
-                    // name is the same risk generalised - its runtime tag
-                    // might be text - and gets the same rejection the
-                    // arithmetic-operand check already gives it elsewhere
-                    // (`check_arithmetic_operand`), for consistency.
+                    // until it wanders off the mapping.
+                    //
+                    // Deliberately NOT rejecting `value`-typed names here:
+                    // unlike bare arithmetic, Increment/Decrement on a
+                    // `value` holding a number already worked correctly
+                    // (inc/dec on its raw integer payload) before this
+                    // check existed, and rejecting it would remove working
+                    // behaviour outside findings 5/15, which are both about
+                    // text. If `value` should eventually be rejected too,
+                    // that is a separate decision, not folded in here.
                     let kw = if matches!(stmt, Statement::Increment { .. }) {
                         "Increment"
                     } else {

--- a/src/analyzer/mod.rs
+++ b/src/analyzer/mod.rs
@@ -563,6 +563,10 @@ pub struct Analyzer {
     source_file: Option<SourceFile>,
     guarded_scopes: HashMap<String, HashSet<String>>,
     symbol_error_counts: HashMap<String, usize>,
+    /// Where each concretely-typed variable was first declared, captured at
+    /// declaration time for the type-lock check's "note: declared here"
+    /// (a variable's type is fixed at declaration and never changes).
+    declared_locations: HashMap<String, SourceLocation>,
     active_guards: Vec<String>,
     in_function_scope: bool,
     block_depth: usize,
@@ -666,6 +670,7 @@ impl Analyzer {
             source_file: None,
             guarded_scopes: HashMap::new(),
             symbol_error_counts: HashMap::new(),
+            declared_locations: HashMap::new(),
             active_guards: Vec::new(),
             in_function_scope: false,
             block_depth: 0,
@@ -1075,6 +1080,67 @@ impl Analyzer {
             Statement::Wait { duration, .. } => self.expr_uses_flag(duration),
             _ => None,
         }
+    }
+
+    /// Like `find_symbol_location`, but for pointing at the specific
+    /// statement that *writes* to `symbol` (`Set symbol to ...` / `symbol is
+    /// ...` / `the symbol is ...`), not just any occurrence of the name.
+    /// `find_symbol_location`'s own preference order (`{symbol` first, for
+    /// format-string interpolation) is wrong here: a name that also appears
+    /// in an unrelated `Print "{n}"` elsewhere in the file would anchor the
+    /// type-lock error there instead of at the offending assignment.
+    fn find_write_site_location(&self, symbol: &str, occurrence: usize) -> Option<SourceLocation> {
+        let source = self.source_file.as_ref()?;
+        // The declaration line is never the offending write - excluding it
+        // matters because the canonical declaration syntax
+        // (`a <type> called X is <value>.`) itself contains `X is `, so an
+        // unfiltered search finds the declaration before the real
+        // reassignment on every plain `X is <value>` case.
+        let decl_line = self.declared_locations.get(symbol).map(|l| l.line);
+        let write_patterns = [
+            format!("Set {} to ", symbol),
+            format!("the {} is ", symbol),
+            format!("{} is ", symbol),
+        ];
+
+        for pattern in write_patterns {
+            let mut seen = 0usize;
+            for (idx, line) in source.content.lines().enumerate() {
+                let line_no = idx + 1;
+                if Some(line_no) == decl_line {
+                    continue;
+                }
+                let mut search_from = 0usize;
+                while let Some(rel) = line[search_from..].find(&pattern) {
+                    let col = search_from + rel;
+                    // Word boundary on the left: the byte before the match
+                    // must not be alphanumeric/'_', otherwise a shorter
+                    // name matches as a suffix of a longer one (symbol "x",
+                    // pattern "x is " matching inside "max is "). The
+                    // pattern's own trailing " is "/" to " already enforces
+                    // the right boundary.
+                    let boundary_ok = col == 0 || {
+                        let prev = line.as_bytes()[col - 1];
+                        !(prev.is_ascii_alphanumeric() || prev == b'_')
+                    };
+                    // A declaration written as `a <type> called X is <v>.`
+                    // contains this exact pattern right after "called " -
+                    // exclude it explicitly as a second guard alongside the
+                    // decl_line skip above (covers a declaration sharing a
+                    // line with something else, however unlikely).
+                    let preceded_by_called = line[..col].ends_with("called ");
+                    if boundary_ok && !preceded_by_called {
+                        if seen == occurrence {
+                            return Some(SourceLocation::new(&source.filename, line_no, col + 1, line));
+                        }
+                        seen += 1;
+                    }
+                    search_from = col + 1;
+                }
+            }
+        }
+
+        self.find_symbol_location(symbol, occurrence)
     }
 
     fn find_symbol_location(&self, symbol: &str, occurrence: usize) -> Option<SourceLocation> {
@@ -1838,6 +1904,128 @@ impl Analyzer {
         }
     }
 
+    /// Render a value expression back into Vox source syntax, for the
+    /// "help: convert it explicitly" suggestion. Only handles the simple
+    /// literal/identifier shapes that are common in a mismatched assignment;
+    /// anything else falls back to a generic placeholder rather than
+    /// fabricating source that wouldn't parse.
+    fn render_value_hint(&self, expr: &Expr) -> String {
+        match expr {
+            Expr::StringLit(s) => format!("\"{}\"", s),
+            Expr::IntegerLit(n) => n.to_string(),
+            Expr::FloatLit(n) => n.to_string(),
+            Expr::BoolLit(b) => if *b { "true".to_string() } else { "false".to_string() },
+            Expr::Identifier(name) => name.clone(),
+            _ => "<value>".to_string(),
+        }
+    }
+
+    /// Type-lock check: a concretely-typed variable's type is fixed at
+    /// declaration and never changes (the language owner's fix for the
+    /// whole "tracked type disagrees with runtime type" bug family - see
+    /// the plan 293 writeup). Reports a compile error naming the variable,
+    /// its declared type, the mismatched type, and the exact cast that
+    /// fixes it when `value`'s type is statically known to differ from
+    /// `name`'s declared type. Returns true iff an error was reported.
+    ///
+    /// Deliberately permissive (returns false, i.e. "allow") when:
+    /// - `name` is `value`-typed (`self.value_typed_names`): that is the
+    ///   language's sanctioned dynamic-type mechanism and must keep
+    ///   accepting varying types.
+    /// - `name`'s declared type can't be resolved (untracked/unknown name -
+    ///   some other check, e.g. unknown-variable, owns that case).
+    /// - `value`'s type can't be determined statically (function calls,
+    ///   property/element access, etc.) - this mirrors the existing
+    ///   `arithmetic_operand_type`/`check_arithmetic_operand` policy of
+    ///   biasing against false positives when static inference runs out,
+    ///   rather than requiring a full type-inference pass this task did not
+    ///   ask for.
+    /// - `value`'s type resolves to `Type::Value` (a dynamically-typed
+    ///   source flowing into a concretely-typed destination): the runtime
+    ///   type isn't known until runtime, so this can't be verified
+    ///   statically either, and there is no sanctioned narrowing syntax to
+    ///   demand here.
+    /// - `name` is a buffer: `X is <value>.` / `Set X to <value>.` on a
+    ///   buffer is a content write (format the value's text into the
+    ///   buffer), not a type change - a buffer legitimately accepts a
+    ///   number, text, or another buffer's contents this way, already
+    ///   special-cased throughout the analyzer/codegen (e.g. the
+    ///   `is_buffer_variable` exclusions the old `Statement::Assignment`
+    ///   arm used before this check replaced it). Locking buffers here
+    ///   would reject `a buffer called b is "".` / `b is 42.`, which must
+    ///   keep working.
+    fn check_type_lock(&mut self, name: &str, value: &Expr) -> bool {
+        if self.value_typed_names.contains(name) || self.is_buffer_variable(name) {
+            return false;
+        }
+        let Some(declared) = self.named_value_type(name) else {
+            return false;
+        };
+        let Some(actual) = self.arithmetic_operand_type(value) else {
+            return false;
+        };
+        if matches!(actual, Type::Value) {
+            return false;
+        }
+        if self.treating_types_compatible(&declared, &actual) {
+            return false;
+        }
+
+        let occurrence = *self.symbol_error_counts.get(name).unwrap_or(&0);
+        let mut err = CompileError::new(&format!(
+            "cannot assign {} to '{}', which is a {}",
+            self.type_name(&actual),
+            name,
+            self.type_name(&declared)
+        ));
+        if let Some(loc) = self.find_write_site_location(name, occurrence) {
+            err = err.with_underline_note(name.len().max(1), &format!("this assigns {}", self.type_name(&actual)));
+            err = err.with_location(loc);
+        }
+        self.symbol_error_counts.insert(name.to_string(), occurrence + 1);
+
+        if let Some(decl_loc) = self.declared_locations.get(name) {
+            err = err.with_note_line(&format!(
+                "'{}' was declared as a {} at {}:{}:{}",
+                name,
+                self.type_name(&declared),
+                decl_loc.file,
+                decl_loc.line,
+                decl_loc.column
+            ));
+        } else {
+            err = err.with_note_line(&format!("'{}' was declared as a {}", name, self.type_name(&declared)));
+        }
+        // Canonical Vox cast phrasing (LANGUAGE.md): `as a number` / `as a
+        // float` / `as a boolean` / `as a buffer`, but `as text` - no
+        // article - specifically for text.
+        let cast_target = if matches!(declared, Type::String) {
+            "text".to_string()
+        } else {
+            format!("a {}", self.type_name(&declared))
+        };
+        err = err.with_help_line(&format!(
+            "convert it explicitly:  {} is {} as {}.",
+            name,
+            self.render_value_hint(value),
+            cast_target
+        ));
+        self.errors.push(err);
+
+        // Poison the tracked type after reporting: the assignment was
+        // rejected, so `name` never actually took on the new type, but
+        // leaving the OLD type in place would make later, unrelated uses of
+        // `name` in this same (already-failing) compile cascade into a
+        // second, confusing error about the mistake that was just rejected
+        // (e.g. `z is s add 1` after a rejected `Set s to 7` re-flagging `s`
+        // as text in arithmetic). The program never reaches codegen once
+        // `self.errors` is non-empty, so this only affects which additional
+        // diagnostics get reported, not correctness.
+        self.scalar_types.remove(name);
+
+        true
+    }
+
     fn validate_treating_expr(&mut self, value: &Expr, match_value: &Expr, replacement: &Expr) {
         if let (Some(match_ty), Some(replacement_ty)) = (
             self.infer_simple_expr_type(match_value),
@@ -1946,6 +2134,14 @@ impl Analyzer {
             }
             
             Statement::VarDecl { name, var_type, value } => {
+                // `Set x to <value>.` / `Create x to <value>.` parse into
+                // this same statement with `var_type: None` regardless of
+                // whether `x` is brand-new or already exists (no explicit
+                // type keyword follows `Set`/`Create`). Only the
+                // already-declared case is a reassignment that the type
+                // lock applies to; a genuinely new `x` is a real
+                // declaration and must infer/lock its type as usual.
+                let was_already_declared = self.is_variable_available(name);
                 self.declare_variable_in_current_scope(name);
                 // Register the declared type in the type-specific sets,
                 // mirroring the top-level pre-pass. That pre-pass only
@@ -2006,6 +2202,21 @@ impl Analyzer {
                         }
                         _ => {}
                     }
+                } else if was_already_declared {
+                    // `Set n to <value>.` on an already-declared `n`: a
+                    // reassignment wearing a declaration's syntax. Enforce
+                    // the lock exactly like `Statement::Assignment` does,
+                    // instead of leaving scalar_types untouched (which is
+                    // how this exact case used to silently retype, or
+                    // silently do nothing, depending on the value's shape).
+                    if let Some(v) = value.as_ref() {
+                        self.check_type_lock(name, v);
+                    }
+                }
+                if !was_already_declared && !self.declared_locations.contains_key(name) {
+                    if let Some(loc) = self.find_symbol_location(name, 0) {
+                        self.declared_locations.insert(name.clone(), loc);
+                    }
                 }
             }
 
@@ -2045,7 +2256,16 @@ impl Analyzer {
             }
             
             Statement::Assignment { name, value } => {
-                if !self.is_variable_available(name) {
+                // A variable's type is fixed at declaration and never
+                // changes (the fix for the whole "tracked type disagrees
+                // with runtime type" bug family). `name is <value>.` is
+                // ambiguous on its own between "declare a brand-new
+                // variable" (valid at top level) and "reassign an existing
+                // one" - which it is decides whether this write gets
+                // type-checked at all, so capture it before the auto-declare
+                // below can change the answer.
+                let was_already_declared = self.is_variable_available(name);
+                if !was_already_declared {
                     if self.in_function_scope {
                         self.push_unknown_variable(name);
                     } else {
@@ -2065,24 +2285,37 @@ impl Analyzer {
 
                 self.analyze_expr(value);
 
-                // Mirror Vox's dynamic typing: a reassignment relabels the
-                // variable to whatever category the value has. `s is 5` turns
-                // a text `s` into a number, so `s add 1` must then be allowed.
-                // When the value's category can't be determined (e.g. a
-                // function result), drop the entry rather than keep a stale
-                // text label that would falsely reject valid arithmetic.
-                if !self.is_buffer_variable(name)
-                    && !self.is_list_variable(name)
-                    && !self.is_map_variable(name)
-                    && !self.file_variables.contains(name.as_str())
-                    && !self.timer_variables.contains(name.as_str())
-                {
-                    match self.arithmetic_operand_type(value) {
-                        Some(t) => {
-                            self.scalar_types.insert(name.clone(), t);
+                if was_already_declared {
+                    // Reassignment of an existing name: enforce the lock
+                    // instead of relabelling scalar_types to match. On a
+                    // mismatch, check_type_lock has already reported the
+                    // error; either way the declared type never changes
+                    // here.
+                    self.check_type_lock(name, value);
+                } else {
+                    // A brand-new name introduced by bare `name is <value>.`
+                    // (valid at top level; the function-scope case above
+                    // already reported "unknown variable") is a genuine
+                    // declaration - infer and lock its type, exactly like an
+                    // explicit `a <type> called name is <value>.` would.
+                    if !self.is_buffer_variable(name)
+                        && !self.is_list_variable(name)
+                        && !self.is_map_variable(name)
+                        && !self.file_variables.contains(name.as_str())
+                        && !self.timer_variables.contains(name.as_str())
+                    {
+                        match self.arithmetic_operand_type(value) {
+                            Some(t) => {
+                                self.scalar_types.insert(name.clone(), t);
+                            }
+                            None => {
+                                self.scalar_types.remove(name);
+                            }
                         }
-                        None => {
-                            self.scalar_types.remove(name);
+                    }
+                    if !self.declared_locations.contains_key(name) {
+                        if let Some(loc) = self.find_symbol_location(name, 0) {
+                            self.declared_locations.insert(name.clone(), loc);
                         }
                     }
                 }

--- a/src/analyzer/mod.rs
+++ b/src/analyzer/mod.rs
@@ -1845,22 +1845,25 @@ impl Analyzer {
             Type::Map(_) => format!("Cannot use map {} in arithmetic.", label),
             Type::File => format!("Cannot use file {} in arithmetic.", label),
             Type::Timer => format!("Cannot use timer {} in arithmetic.", label),
-            // Deliberately NOT "check its type with 'is a number' first":
-            // verified that guard does not narrow the type inside its own
-            // body, so the advice would be a dead end (still rejected
-            // after doing exactly what it says). `as a number`/`as text`
-            // is the escape hatch that LANGUAGE.md documents and that
-            // actually compiles - though it's only proven correct here
-            // when the value's tag is statically known; a value whose tag
-            // is genuinely only known at runtime (e.g. from a map read, or
-            // plan 294 finding 18's heterogeneous-list loop variable) casts
-            // without error but silently reads the wrong bytes - a
-            // separate, pre-existing codegen gap (confirmed on unmodified
-            // `main`, unrelated to this track) in Cast not consulting the
-            // runtime tag. Recording that here rather than in a hint
-            // string a `.err` fixture would have to pin.
+            // Deliberately naming no escape hatch, after two rounds of
+            // getting this wrong: "check its type with 'is a number'
+            // first" was a dead end (a type-predicate guard does not
+            // narrow the type inside its own body - still rejected there
+            // too), and "convert it explicitly with 'as a number'" was
+            // ALSO a dead end once finding 21's fix made exactly that cast
+            // a compile error (plan 294 finding 21 - casting a
+            // dynamically-tagged value doesn't dispatch on the runtime tag
+            // in codegen, so it used to silently compute garbage; rejecting
+            // it was the fix, but this message kept sending people to it
+            // anyway). This is the value-typed case by construction - it
+            // is the ONLY way this branch fires - so every occurrence of
+            // this message hits both dead ends the same way, every time.
+            // There is currently no supported way to use a dynamically-
+            // tagged value in arithmetic; say only that, since a plausible-
+            // sounding but unverified alternative is worse than none (that
+            // is exactly how the previous two wordings went wrong).
             Type::Value => format!(
-                "Cannot use a value {} in arithmetic; convert it explicitly first with 'as a number' or 'as text'.",
+                "Cannot use a value {} in arithmetic: its type is only known at runtime, and arithmetic on a dynamically-tagged value is not currently supported.",
                 label
             ),
             _ => return,

--- a/src/analyzer/mod.rs
+++ b/src/analyzer/mod.rs
@@ -2049,7 +2049,7 @@ impl Analyzer {
             self.type_name(&declared)
         ));
         if let Some(loc) = self.find_write_site_location(name, occurrence) {
-            err = err.with_underline_note(name.len().max(1), &format!("this assigns {}", self.type_name(&actual)));
+            err = err.with_underline_note(name.len().max(1), &format!("this assigns {}", self.typed_phrase(&actual)));
             err = err.with_location(loc);
         }
         self.symbol_error_counts.insert(name.to_string(), occurrence + 1);
@@ -2170,7 +2170,7 @@ impl Analyzer {
         if let Some(loc) = self.find_bind_site_location(name, patterns, occurrence, guard_against_called) {
             err = err.with_underline_note(
                 name.len().max(1),
-                &format!("this {} {}", bind_verb, self.type_name(&new_type)),
+                &format!("this {} {}", bind_verb, self.typed_phrase(&new_type)),
             );
             err = err.with_location(loc);
         }
@@ -2803,6 +2803,8 @@ impl Analyzer {
                     || self.file_variables.contains(name.as_str())
                     || self.flag_variables.contains(name.as_str())
                     || self.timer_variables.contains(name.as_str())
+                    || matches!(self.named_value_type(name), Some(Type::String))
+                    || self.value_typed_names.contains(name.as_str())
                 {
                     // Increment/Decrement compile to an integer `inc/dec
                     // qword` on the variable's stack slot. Applied to a
@@ -2811,15 +2813,38 @@ impl Analyzer {
                     // struct (also corrupted), and to a boolean flag it
                     // yields 2, 3, ... instead of a boolean. Reject these
                     // rather than emit undefined behaviour.
+                    //
+                    // A declared-text variable is the same defect the type
+                    // lock elsewhere in this file exists to close, but this
+                    // one is not a type CHANGE - tracking is correct, `name`
+                    // really is text - so the lock doesn't see it (plan 294
+                    // findings 5/15): the pointer just gets walked one byte
+                    // at a time with no relationship to the string's bounds
+                    // until it wanders off the mapping. A `value`-typed
+                    // name is the same risk generalised - its runtime tag
+                    // might be text - and gets the same rejection the
+                    // arithmetic-operand check already gives it elsewhere
+                    // (`check_arithmetic_operand`), for consistency.
                     let kw = if matches!(stmt, Statement::Increment { .. }) {
                         "Increment"
                     } else {
                         "Decrement"
                     };
-                    self.push_error(
-                        format!("{} requires a number variable: {}", kw, name),
-                        Some(name),
-                    );
+                    // Built directly rather than via `push_error` so the
+                    // pointer lands on the `Increment`/`Decrement` line
+                    // itself: `push_error`'s `find_symbol_location` prefers
+                    // `{name` (format-string interpolation) as its first
+                    // pattern, which would anchor on an unrelated
+                    // `Print "{s}"` elsewhere in the same program instead.
+                    let occurrence = *self.symbol_error_counts.get(name).unwrap_or(&0);
+                    let mut err = CompileError::new(&format!("{} requires a number variable: {}", kw, name));
+                    let patterns = [format!("{} {}", kw, name)];
+                    if let Some(loc) = self.find_bind_site_location(name, &patterns, occurrence, true) {
+                        err = err.with_underline_note(name.len().max(1), "not a number here");
+                        err = err.with_location(loc);
+                    }
+                    self.symbol_error_counts.insert(name.to_string(), occurrence + 1);
+                    self.errors.push(err);
                 }
             }
             

--- a/src/analyzer/mod.rs
+++ b/src/analyzer/mod.rs
@@ -1082,6 +1082,79 @@ impl Analyzer {
         }
     }
 
+    /// Core of `find_write_site_location`/`find_bind_site_location`: search
+    /// `patterns` in order, skipping `exclude_line` (the declaration, when
+    /// known) and requiring a left word boundary so a shorter name doesn't
+    /// match as a suffix of a longer one (symbol "x", pattern "x is "
+    /// matching inside "max is " - each pattern's own trailing space
+    /// already enforces the right boundary). `guard_against_called`
+    /// additionally excludes a match immediately preceded by "called " -
+    /// the canonical declaration syntax `a <type> called X is <value>.`
+    /// contains `X is ` right after it, so an "X is "-shaped pattern needs
+    /// this guard as a second line of defence alongside `exclude_line`
+    /// (which only covers the *recorded* declaration line, e.g. if a
+    /// declaration and something else ever shared one line). A
+    /// construct-specific pattern that legitimately targets "called X"
+    /// itself (`FileOpen`'s own syntax) must pass `false` here so it does
+    /// not exclude its own match.
+    /// Search `patterns` (each expected to contain `symbol` as a
+    /// substring) for the statement that binds/writes `symbol`, returning
+    /// the location of `symbol` itself within the match - not the
+    /// pattern's own start. That distinction matters: a pattern like
+    /// `"Set {symbol} to "` has the symbol sitting *inside* it, offset by
+    /// `len("Set ")`, so anchoring on the pattern's start would draw the
+    /// caret under `Set` while claiming to point at the variable. Boundary
+    /// checks (word boundary on both sides of `symbol`, and optionally
+    /// "not immediately preceded by `called `") are applied around the
+    /// symbol's own span for the same reason - a boundary check anchored on
+    /// the pattern's start protects the wrong substring whenever the symbol
+    /// isn't at offset 0.
+    fn find_pattern_location(
+        &self,
+        symbol: &str,
+        patterns: &[String],
+        occurrence: usize,
+        exclude_line: Option<usize>,
+        guard_against_called: bool,
+    ) -> Option<SourceLocation> {
+        let source = self.source_file.as_ref()?;
+        for pattern in patterns {
+            let Some(name_offset) = pattern.find(symbol) else {
+                continue;
+            };
+            let mut seen = 0usize;
+            for (idx, line) in source.content.lines().enumerate() {
+                let line_no = idx + 1;
+                if Some(line_no) == exclude_line {
+                    continue;
+                }
+                let mut search_from = 0usize;
+                while let Some(rel) = line[search_from..].find(pattern.as_str()) {
+                    let pat_col = search_from + rel;
+                    let name_col = pat_col + name_offset;
+                    let name_end = name_col + symbol.len();
+                    let left_ok = name_col == 0 || {
+                        let prev = line.as_bytes()[name_col - 1];
+                        !(prev.is_ascii_alphanumeric() || prev == b'_')
+                    };
+                    let right_ok = line
+                        .as_bytes()
+                        .get(name_end)
+                        .is_none_or(|b| !(b.is_ascii_alphanumeric() || *b == b'_'));
+                    let excluded_by_called = guard_against_called && line[..pat_col].ends_with("called ");
+                    if left_ok && right_ok && !excluded_by_called {
+                        if seen == occurrence {
+                            return Some(SourceLocation::new(&source.filename, line_no, name_col + 1, line));
+                        }
+                        seen += 1;
+                    }
+                    search_from = pat_col + 1;
+                }
+            }
+        }
+        None
+    }
+
     /// Like `find_symbol_location`, but for pointing at the specific
     /// statement that *writes* to `symbol` (`Set symbol to ...` / `symbol is
     /// ...` / `the symbol is ...`), not just any occurrence of the name.
@@ -1090,57 +1163,54 @@ impl Analyzer {
     /// in an unrelated `Print "{n}"` elsewhere in the file would anchor the
     /// type-lock error there instead of at the offending assignment.
     fn find_write_site_location(&self, symbol: &str, occurrence: usize) -> Option<SourceLocation> {
-        let source = self.source_file.as_ref()?;
-        // The declaration line is never the offending write - excluding it
-        // matters because the canonical declaration syntax
-        // (`a <type> called X is <value>.`) itself contains `X is `, so an
-        // unfiltered search finds the declaration before the real
-        // reassignment on every plain `X is <value>` case.
         let decl_line = self.declared_locations.get(symbol).map(|l| l.line);
         let write_patterns = [
             format!("Set {} to ", symbol),
             format!("the {} is ", symbol),
             format!("{} is ", symbol),
         ];
+        self.find_pattern_location(symbol, &write_patterns, occurrence, decl_line, true)
+            .or_else(|| self.find_symbol_location(symbol, occurrence))
+    }
 
-        for pattern in write_patterns {
-            let mut seen = 0usize;
-            for (idx, line) in source.content.lines().enumerate() {
-                let line_no = idx + 1;
-                if Some(line_no) == decl_line {
-                    continue;
-                }
-                let mut search_from = 0usize;
-                while let Some(rel) = line[search_from..].find(&pattern) {
-                    let col = search_from + rel;
-                    // Word boundary on the left: the byte before the match
-                    // must not be alphanumeric/'_', otherwise a shorter
-                    // name matches as a suffix of a longer one (symbol "x",
-                    // pattern "x is " matching inside "max is "). The
-                    // pattern's own trailing " is "/" to " already enforces
-                    // the right boundary.
-                    let boundary_ok = col == 0 || {
-                        let prev = line.as_bytes()[col - 1];
-                        !(prev.is_ascii_alphanumeric() || prev == b'_')
-                    };
-                    // A declaration written as `a <type> called X is <v>.`
-                    // contains this exact pattern right after "called " -
-                    // exclude it explicitly as a second guard alongside the
-                    // decl_line skip above (covers a declaration sharing a
-                    // line with something else, however unlikely).
-                    let preceded_by_called = line[..col].ends_with("called ");
-                    if boundary_ok && !preceded_by_called {
-                        if seen == occurrence {
-                            return Some(SourceLocation::new(&source.filename, line_no, col + 1, line));
-                        }
-                        seen += 1;
-                    }
-                    search_from = col + 1;
-                }
-            }
-        }
+    /// Like `find_write_site_location`, for a statement that *binds* `name`
+    /// through some construct-specific syntax rather than `is`/`to`
+    /// (a for-range/for-each loop header, `open ... called X`, `Allocate N
+    /// for X`). `patterns` are the construct's own syntax fragments
+    /// (e.g. `"each {name} "`, `"called {name} "`); `guard_against_called`
+    /// should be `false` when a pattern itself targets `"called X"`; a
+    /// caller doing that must instead disambiguate the declaration via
+    /// `exclude_line`.
+    fn find_bind_site_location(
+        &self,
+        symbol: &str,
+        patterns: &[String],
+        occurrence: usize,
+        guard_against_called: bool,
+    ) -> Option<SourceLocation> {
+        let decl_line = self.declared_locations.get(symbol).map(|l| l.line);
+        self.find_pattern_location(symbol, patterns, occurrence, decl_line, guard_against_called)
+            .or_else(|| self.find_symbol_location(symbol, occurrence))
+    }
 
-        self.find_symbol_location(symbol, occurrence)
+    /// Where `name` was declared, for `declared_locations`. Deliberately
+    /// does NOT use `find_symbol_location`: that function prefers `{name`
+    /// (format-string interpolation) as its first pattern, which is right
+    /// for "where is this name used" but wrong here - a `Print "{src}"`
+    /// anywhere in the file would outrank the actual `a text called src
+    /// is ...` declaration, since interpolation is usually textually
+    /// earlier or just as likely to hit occurrence 0. Tries the `called
+    /// NAME` declaration syntax first (typed declarations, `Allocate`,
+    /// `FileOpen`, ...), then falls back to bare/loop-header forms that
+    /// have no `called` keyword at all (`NAME is <value>.`, `each NAME `).
+    fn find_declaration_location(&self, name: &str) -> Option<SourceLocation> {
+        let called_patterns = [format!("called {} is", name), format!("called {} ", name)];
+        self.find_pattern_location(name, &called_patterns, 0, None, false)
+            .or_else(|| {
+                let bare_patterns = [format!("{} is ", name), format!("each {} ", name)];
+                self.find_pattern_location(name, &bare_patterns, 0, None, false)
+            })
+            .or_else(|| self.find_symbol_location(name, 0))
     }
 
     fn find_symbol_location(&self, symbol: &str, occurrence: usize) -> Option<SourceLocation> {
@@ -2026,6 +2096,108 @@ impl Analyzer {
         true
     }
 
+    /// `a {} number` / `text` / etc. - the article Vox's own cast syntax
+    /// uses (`as a number`, but `as text` with none). Shared by
+    /// `check_type_lock` and `bind_variable_type` so both error shapes
+    /// agree.
+    fn typed_phrase(&self, ty: &Type) -> String {
+        if matches!(ty, Type::String) {
+            "text".to_string()
+        } else {
+            format!("a {}", self.type_name(ty))
+        }
+    }
+
+    /// Statement-level binder for constructs that put a new runtime value
+    /// into `name` WITHOUT going through `Statement::Assignment`/`VarDecl`
+    /// - a for-range/for-each loop header, `open ... called X`, `Allocate N
+    /// for X`. A binding is not an assignment, but plan 294's audit found
+    /// six such sites still segfault under a rule enforced only on
+    /// assignment, because each one rebinds an existing name to a new
+    /// runtime value without updating (or checking) its tracked type. Same
+    /// rule, same rejection: if `name` is already declared with a type
+    /// incompatible with `new_type`, this is a compile error. If `name` is
+    /// new, this call IS the declaration - `new_type` becomes its locked
+    /// type, exactly as a `VarDecl` would set it.
+    ///
+    /// `construct`/`bind_verb` describe the site in the error text (e.g.
+    /// "this for-range loop" / "counts with"). `patterns` locate the
+    /// binding statement for the caret, tried in order via
+    /// `find_bind_site_location`; `guard_against_called` must be `false`
+    /// when a pattern itself targets literal `"called X"` syntax (so it
+    /// does not exclude its own match - see that function's docs).
+    ///
+    /// Exempt exactly like `check_type_lock`: `value`-typed names (the
+    /// sanctioned dynamic mechanism) and buffers (binding into a buffer is
+    /// a content write, not a type change).
+    fn bind_variable_type(
+        &mut self,
+        name: &str,
+        new_type: Type,
+        construct: &str,
+        bind_verb: &str,
+        patterns: &[String],
+        guard_against_called: bool,
+    ) -> bool {
+        if self.value_typed_names.contains(name) || self.is_buffer_variable(name) {
+            return false;
+        }
+        let Some(declared) = self.named_value_type(name) else {
+            // A brand-new name: this binding is the declaration.
+            if matches!(new_type, Type::Integer | Type::Float | Type::Boolean | Type::String) {
+                self.scalar_types.insert(name.to_string(), new_type);
+            }
+            if !self.declared_locations.contains_key(name) {
+                if let Some(loc) = self.find_declaration_location(name) {
+                    self.declared_locations.insert(name.to_string(), loc);
+                }
+            }
+            return false;
+        };
+        if self.treating_types_compatible(&declared, &new_type) {
+            return false;
+        }
+
+        let occurrence = *self.symbol_error_counts.get(name).unwrap_or(&0);
+        let mut err = CompileError::new(&format!(
+            "cannot bind '{}' to {} in {}; '{}' is already declared as {}",
+            name,
+            self.typed_phrase(&new_type),
+            construct,
+            name,
+            self.typed_phrase(&declared)
+        ));
+        if let Some(loc) = self.find_bind_site_location(name, patterns, occurrence, guard_against_called) {
+            err = err.with_underline_note(
+                name.len().max(1),
+                &format!("this {} {}", bind_verb, self.type_name(&new_type)),
+            );
+            err = err.with_location(loc);
+        }
+        self.symbol_error_counts.insert(name.to_string(), occurrence + 1);
+
+        if let Some(decl_loc) = self.declared_locations.get(name) {
+            err = err.with_note_line(&format!(
+                "'{}' was declared as {} at {}:{}:{}",
+                name,
+                self.typed_phrase(&declared),
+                decl_loc.file,
+                decl_loc.line,
+                decl_loc.column
+            ));
+        } else {
+            err = err.with_note_line(&format!("'{}' was declared as {}", name, self.typed_phrase(&declared)));
+        }
+        err = err.with_help_line(&format!(
+            "use a different name here, or declare '{}' as {} instead",
+            name,
+            self.typed_phrase(&new_type)
+        ));
+        self.errors.push(err);
+        self.scalar_types.remove(name);
+        true
+    }
+
     fn validate_treating_expr(&mut self, value: &Expr, match_value: &Expr, replacement: &Expr) {
         if let (Some(match_ty), Some(replacement_ty)) = (
             self.infer_simple_expr_type(match_value),
@@ -2213,8 +2385,16 @@ impl Analyzer {
                         self.check_type_lock(name, v);
                     }
                 }
-                if !was_already_declared && !self.declared_locations.contains_key(name) {
-                    if let Some(loc) = self.find_symbol_location(name, 0) {
+                // Record the declaration site the first time we see a real
+                // type for `name`, regardless of `was_already_declared`: a
+                // global pre-pass (`self.variables = self.global_variables
+                // .clone()` before the main walk, fed by
+                // `collect_definite_decls`) makes every top-level name
+                // "already available" from the very first statement, so
+                // `was_already_declared` is always true here for a
+                // top-level declaration and can't be used to gate this.
+                if !self.declared_locations.contains_key(name) {
+                    if let Some(loc) = self.find_declaration_location(name) {
                         self.declared_locations.insert(name.clone(), loc);
                     }
                 }
@@ -2314,7 +2494,7 @@ impl Analyzer {
                         }
                     }
                     if !self.declared_locations.contains_key(name) {
-                        if let Some(loc) = self.find_symbol_location(name, 0) {
+                        if let Some(loc) = self.find_declaration_location(name) {
                             self.declared_locations.insert(name.clone(), loc);
                         }
                     }
@@ -2380,8 +2560,19 @@ impl Analyzer {
 
             Statement::ForRange { variable, range, body } => {
                 self.variables.insert(variable.clone());
-                // A range loop variable steps over integers.
-                self.scalar_types.insert(variable.clone(), Type::Integer);
+                // A range loop variable steps over integers - reusing a
+                // name already declared with a different type is a rebind,
+                // same rule as `Set`/`is` (plan 294 finding 2: this used to
+                // leave the old label in place and segfault when the
+                // formatter dereferenced the loop counter as a pointer).
+                self.bind_variable_type(
+                    variable,
+                    Type::Integer,
+                    "this for-range loop",
+                    "counts with",
+                    &[format!("each {} ", variable)],
+                    true,
+                );
                 self.analyze_expr(range);
                 self.loop_depth += 1;
                 for s in body {
@@ -2442,9 +2633,18 @@ impl Analyzer {
                 self.deps.uses_heap = true;
                 self.variables.insert(name.clone());
                 self.allocated_variables.insert(name.clone());
-                // The variable now holds a raw pointer, not its previous
-                // scalar value - drop any stale number/text label.
-                self.scalar_types.remove(name);
+                // The variable now holds a raw pointer, rendered as a
+                // number when printed - a rebind like any other (plan 294
+                // finding 17: codegen used to leave a stale text label in
+                // place, formatting the fresh allocation as a C string).
+                self.bind_variable_type(
+                    name,
+                    Type::Integer,
+                    "this Allocate statement",
+                    "allocates",
+                    &[format!("for {}", name)],
+                    true,
+                );
                 self.analyze_expr(size);
             }
 
@@ -2794,6 +2994,20 @@ impl Analyzer {
             }
             
             Statement::FileOpen { name, path, .. } => {
+                // `open ... called X` binds X to a file descriptor - a
+                // rebind like any other if X already exists with an
+                // incompatible type (plan 294 finding 3: this used to leave
+                // a stale text label in place and dereference the fd as a
+                // string pointer). Checked before registering `name` as a
+                // file below, so it sees the pre-existing declared type.
+                self.bind_variable_type(
+                    name,
+                    Type::File,
+                    "this open statement",
+                    "opens as",
+                    &[format!("called {} ", name)],
+                    false,
+                );
                 self.variables.insert(name.clone());
                 self.file_variables.insert(name.clone());
                 self.analyze_expr(path);

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -35,6 +35,12 @@ pub struct CompileError {
     /// gutter line), carrying the migration suggestion. Rendered as plain
     /// text so `.err` fixtures can assert on it verbatim.
     pub help_line: Option<String>,
+    /// A `note:` line rendered after the pointer, before `help_line` -
+    /// typically a second, unrelated location (e.g. where a variable was
+    /// originally declared, for a type-mismatch error whose primary pointer
+    /// is at the offending assignment). Plain text, same reasoning as
+    /// `help_line`.
+    pub note_line: Option<String>,
 }
 
 impl CompileError {
@@ -48,6 +54,7 @@ impl CompileError {
             error_code: None,
             underline_note: None,
             help_line: None,
+            note_line: None,
         }
     }
 
@@ -83,6 +90,14 @@ impl CompileError {
     /// `length` characters starting at the error's location column.
     pub fn with_underline_note(mut self, length: usize, note: &str) -> Self {
         self.underline_note = Some((length, note.to_string()));
+        self
+    }
+
+    /// Attach a `note:` line - typically a second, unrelated source
+    /// location spelled out as plain text (e.g. a variable's declaration
+    /// site), rendered before `help_line`.
+    pub fn with_note_line(mut self, note: &str) -> Self {
+        self.note_line = Some(note.to_string());
         self
     }
 
@@ -172,11 +187,17 @@ impl fmt::Display for CompileError {
                 return Ok(());  // Skip normal hint display
             }
 
-            // Plan 270 §S1.5: a dedicated `help:` line, rendered after the
-            // pointer with a blank gutter line. Plain text (no colour) so
-            // `tests/compile_fail/*.err` fixtures can assert it verbatim.
-            if let Some(ref help) = self.help_line {
+            // A dedicated `note:`/`help:` pair, rendered after the pointer
+            // with a single shared blank gutter line. Plain text (no
+            // colour) so `tests/compile_fail/*.err` fixtures can assert
+            // them verbatim.
+            if self.note_line.is_some() || self.help_line.is_some() {
                 write!(f, "  {:width$} {}|\n", "", BLUE, width = line_num_width)?;
+            }
+            if let Some(ref note) = self.note_line {
+                write!(f, "  note: {}\n", note)?;
+            }
+            if let Some(ref help) = self.help_line {
                 write!(f, "  help: {}\n", help)?;
             }
         }

--- a/src/parser/ast.rs
+++ b/src/parser/ast.rs
@@ -641,6 +641,41 @@ pub enum DefiniteDeclKind {
 /// declarations behave as globals.
 pub fn collect_definite_decls(stmts: &[Statement]) -> std::collections::HashMap<String, DefiniteDeclKind> {
     let mut out = std::collections::HashMap::new();
+    // A name whose recognised occurrences disagree on kind (e.g. `a text
+    // called src is "hello".` followed later by `open ... called src`,
+    // which this function would otherwise see as `Plain` then `File`) is
+    // poisoned: removed from `out` and never re-added, rather than letting
+    // whichever occurrence is scanned last silently win. That "last write
+    // wins" used to pre-register the *later* kind (into
+    // buffer_variables/list_variables/map_variables/file_variables) before
+    // the analyzer's own per-statement, declaration-order-respecting
+    // type-immutability check ever ran - masking the real conflict instead
+    // of surfacing it (plan 294 finding 3). A poisoned name is simply
+    // absent from the definite-decl map; the analyzer's linear walk still
+    // sees and rejects the conflict when it reaches the second occurrence,
+    // it just does so without this pre-pass having pre-judged the type.
+    let mut poisoned: std::collections::HashSet<String> = std::collections::HashSet::new();
+
+    fn record(
+        out: &mut std::collections::HashMap<String, DefiniteDeclKind>,
+        poisoned: &mut std::collections::HashSet<String>,
+        name: &str,
+        kind: DefiniteDeclKind,
+    ) {
+        if poisoned.contains(name) {
+            return;
+        }
+        match out.get(name) {
+            Some(existing) if *existing != kind => {
+                out.remove(name);
+                poisoned.insert(name.to_string());
+            }
+            _ => {
+                out.insert(name.to_string(), kind);
+            }
+        }
+    }
+
     for stmt in stmts {
         match stmt {
             Statement::VarDecl { name, var_type, .. } => {
@@ -650,19 +685,19 @@ pub fn collect_definite_decls(stmts: &[Statement]) -> std::collections::HashMap<
                     Some(Type::Map(_)) => DefiniteDeclKind::Map,
                     _ => DefiniteDeclKind::Plain,
                 };
-                out.insert(name.clone(), kind);
+                record(&mut out, &mut poisoned, name, kind);
             }
             Statement::BufferDecl { name, .. } => {
-                out.insert(name.clone(), DefiniteDeclKind::Buffer);
+                record(&mut out, &mut poisoned, name, DefiniteDeclKind::Buffer);
             }
             Statement::Allocate { name, .. } | Statement::TimerDecl { name } => {
-                out.insert(name.clone(), DefiniteDeclKind::Plain);
+                record(&mut out, &mut poisoned, name, DefiniteDeclKind::Plain);
             }
             Statement::FileOpen { name, .. } => {
-                out.insert(name.clone(), DefiniteDeclKind::File);
+                record(&mut out, &mut poisoned, name, DefiniteDeclKind::File);
             }
             Statement::GetTime { into } => {
-                out.insert(into.clone(), DefiniteDeclKind::Plain);
+                record(&mut out, &mut poisoned, into, DefiniteDeclKind::Plain);
             }
             Statement::If { then_block, else_if_blocks, else_block: Some(else_block), .. } => {
                 let mut definite = collect_definite_decls(then_block);
@@ -672,7 +707,9 @@ pub fn collect_definite_decls(stmts: &[Statement]) -> std::collections::HashMap<
                 }
                 let branch = collect_definite_decls(else_block);
                 definite.retain(|name, kind| branch.get(name) == Some(kind));
-                out.extend(definite);
+                for (name, kind) in definite {
+                    record(&mut out, &mut poisoned, &name, kind);
+                }
             }
             _ => {}
         }

--- a/tests/149_cast_in_arithmetic.vox
+++ b/tests/149_cast_in_arithmetic.vox
@@ -9,8 +9,9 @@
     immediately to its left; brace to cast a whole expression.
  3. Bare text in arithmetic used to compile to pointer arithmetic and print
     garbage; it now errors at analysis time. Casts do atoi/atof and pass.
- Dynamic relabeling: a text var reassigned to a number may then be used in
- arithmetic without a cast.)
+ A variable's declared type is now fixed for good (plan 294): reassigning
+ `dyn` to a number is a compile error, so arithmetic on it goes through an
+ explicit cast at the use site instead of relying on dynamic relabeling.)
 
 a text called s is "42".
 a text called sf is "3.5".
@@ -21,9 +22,8 @@ a number called ic is {s as a number} add 1.
 a float called fc1 is {sf as a float} add 1.
 a float called fc2 is {sf as a float} multiply 2.
 a float called fc3 is {sf as a float} subtract 0.5.
-a text called dyn is "hi".
-dyn is 5.
-a number called dynr is dyn add 1.
+a text called dyn is "5".
+a number called dynr is dyn as a number add 1.
 Print tight1.
 Print tight2.
 Print rounded.

--- a/tests/compile_fail/051_value_in_arithmetic.err
+++ b/tests/compile_fail/051_value_in_arithmetic.err
@@ -1,1 +1,1 @@
-Cannot use a value v in arithmetic; convert it explicitly first with 'as a number' or 'as text'.
+Cannot use a value v in arithmetic: its type is only known at runtime, and arithmetic on a dynamically-tagged value is not currently supported.

--- a/tests/compile_fail/051_value_in_arithmetic.err
+++ b/tests/compile_fail/051_value_in_arithmetic.err
@@ -1,1 +1,1 @@
-Cannot use a value v in arithmetic; check its type with 'is a number'/'is a text' first.
+Cannot use a value v in arithmetic; convert it explicitly first with 'as a number' or 'as text'.

--- a/tests/compile_fail/073_type_lock_caret_points_at_write_site.err
+++ b/tests/compile_fail/073_type_lock_caret_points_at_write_site.err
@@ -1,0 +1,4 @@
+cannot assign text to 'n', which is a number
+073_type_lock_caret_points_at_write_site.vox:4:1
+note: 'n' was declared as a number
+help: convert it explicitly:  n is "abc" as a number.

--- a/tests/compile_fail/073_type_lock_caret_points_at_write_site.vox
+++ b/tests/compile_fail/073_type_lock_caret_points_at_write_site.vox
@@ -1,0 +1,5 @@
+a number called n is 5.
+Print "start".
+Print "middle".
+n is "abc".
+Print "{n}".

--- a/tests/compile_fail/074_type_lock_forrange_loopvar_rebind.err
+++ b/tests/compile_fail/074_type_lock_forrange_loopvar_rebind.err
@@ -1,0 +1,4 @@
+cannot bind 'i' to a number in this for-range loop; 'i' is already declared as text
+074_type_lock_forrange_loopvar_rebind.vox:2:10
+note: 'i' was declared as text at 074_type_lock_forrange_loopvar_rebind.vox:1:15
+help: use a different name here, or declare 'i' as a number instead

--- a/tests/compile_fail/074_type_lock_forrange_loopvar_rebind.vox
+++ b/tests/compile_fail/074_type_lock_forrange_loopvar_rebind.vox
@@ -1,0 +1,3 @@
+a text called i is "hello".
+For each i from 1 to 3,
+  Print "in {i}".

--- a/tests/compile_fail/075_type_lock_fileopen_name_rebind.err
+++ b/tests/compile_fail/075_type_lock_fileopen_name_rebind.err
@@ -1,0 +1,4 @@
+cannot bind 'src' to a file in this open statement; 'src' is already declared as text
+075_type_lock_fileopen_name_rebind.vox:2:32
+note: 'src' was declared as text at 075_type_lock_fileopen_name_rebind.vox:1:15
+help: use a different name here, or declare 'src' as a file instead

--- a/tests/compile_fail/075_type_lock_fileopen_name_rebind.vox
+++ b/tests/compile_fail/075_type_lock_fileopen_name_rebind.vox
@@ -1,0 +1,3 @@
+a text called src is "hello".
+open a file for reading called src at "/etc/hostname".
+Print "[{src}]".

--- a/tests/compile_fail/076_type_lock_allocate_name_rebind.err
+++ b/tests/compile_fail/076_type_lock_allocate_name_rebind.err
@@ -1,0 +1,4 @@
+cannot bind 'p' to a number in this Allocate statement; 'p' is already declared as text
+076_type_lock_allocate_name_rebind.vox:2:18
+note: 'p' was declared as text at 076_type_lock_allocate_name_rebind.vox:1:15
+help: use a different name here, or declare 'p' as a number instead

--- a/tests/compile_fail/076_type_lock_allocate_name_rebind.vox
+++ b/tests/compile_fail/076_type_lock_allocate_name_rebind.vox
@@ -1,0 +1,3 @@
+a text called p is "hello".
+Allocate 100 for p.
+Print "{p}".

--- a/tests/compile_fail/077_increment_text_variable_rejected.err
+++ b/tests/compile_fail/077_increment_text_variable_rejected.err
@@ -1,0 +1,3 @@
+Increment requires a number variable: s
+077_increment_text_variable_rejected.vox:2:11
+not a number here

--- a/tests/compile_fail/077_increment_text_variable_rejected.vox
+++ b/tests/compile_fail/077_increment_text_variable_rejected.vox
@@ -1,0 +1,3 @@
+a text called s is "hi".
+Increment s.
+Print "[{s}]".

--- a/tests/compile_fail/078_decrement_text_variable_rejected.err
+++ b/tests/compile_fail/078_decrement_text_variable_rejected.err
@@ -1,0 +1,3 @@
+Decrement requires a number variable: s
+078_decrement_text_variable_rejected.vox:2:11
+not a number here

--- a/tests/compile_fail/078_decrement_text_variable_rejected.vox
+++ b/tests/compile_fail/078_decrement_text_variable_rejected.vox
@@ -1,0 +1,3 @@
+a text called s is "hello".
+Decrement s.
+Print "[{s}]".

--- a/tests/compile_fail/079_type_lock_nested_declaration_rebind.err
+++ b/tests/compile_fail/079_type_lock_nested_declaration_rebind.err
@@ -1,0 +1,4 @@
+cannot bind 'n' to text in this declaration; 'n' is already declared as a number
+079_type_lock_nested_declaration_rebind.vox:3:17
+note: 'n' was declared as a number at 079_type_lock_nested_declaration_rebind.vox:1:17
+help: use a different name here, or declare 'n' as text instead

--- a/tests/compile_fail/079_type_lock_nested_declaration_rebind.vox
+++ b/tests/compile_fail/079_type_lock_nested_declaration_rebind.vox
@@ -1,0 +1,5 @@
+a number called n is 5.
+If 1 is equal to 2,
+  a text called n is "abc".
+
+Print "outer [{n}]".

--- a/tests/compile_fail/080_mixed_list_loopvar_requires_check.err
+++ b/tests/compile_fail/080_mixed_list_loopvar_requires_check.err
@@ -1,0 +1,1 @@
+Cannot use a value item in arithmetic; convert it explicitly first with 'as a number' or 'as text'.

--- a/tests/compile_fail/080_mixed_list_loopvar_requires_check.err
+++ b/tests/compile_fail/080_mixed_list_loopvar_requires_check.err
@@ -1,1 +1,1 @@
-Cannot use a value item in arithmetic; convert it explicitly first with 'as a number' or 'as text'.
+Cannot use a value item in arithmetic: its type is only known at runtime, and arithmetic on a dynamically-tagged value is not currently supported.

--- a/tests/compile_fail/080_mixed_list_loopvar_requires_check.vox
+++ b/tests/compile_fail/080_mixed_list_loopvar_requires_check.vox
@@ -1,0 +1,4 @@
+a list called data is [42, "hello"].
+For each item in data,
+  a number called z is item add 1,
+  Print "z={z}".

--- a/tests/compile_fail/081_type_lock_map_numeric_value_into_text.err
+++ b/tests/compile_fail/081_type_lock_map_numeric_value_into_text.err
@@ -1,0 +1,4 @@
+cannot assign number to 's', which is a text
+081_type_lock_map_numeric_value_into_text.vox:3:1
+note: 's' was declared as a text at 081_type_lock_map_numeric_value_into_text.vox:2:15
+help: convert it explicitly:  s is <value> as text.

--- a/tests/compile_fail/081_type_lock_map_numeric_value_into_text.vox
+++ b/tests/compile_fail/081_type_lock_map_numeric_value_into_text.vox
@@ -1,0 +1,4 @@
+a map called m is {"k": 42}.
+a text called s is "hello".
+s is m's "k".
+Print "[{s}]".

--- a/tests/compile_fail/082_type_lock_map_text_value_into_number.err
+++ b/tests/compile_fail/082_type_lock_map_text_value_into_number.err
@@ -1,0 +1,4 @@
+cannot assign text to 'n', which is a number
+082_type_lock_map_text_value_into_number.vox:3:1
+note: 'n' was declared as a number at 082_type_lock_map_text_value_into_number.vox:2:17
+help: convert it explicitly:  n is <value> as a number.

--- a/tests/compile_fail/082_type_lock_map_text_value_into_number.vox
+++ b/tests/compile_fail/082_type_lock_map_text_value_into_number.vox
@@ -1,0 +1,4 @@
+a map called m is {"k": "abc"}.
+a number called n is 5.
+n is m's "k".
+Print "{n}".

--- a/tests/compile_fail/083_dynamic_value_cast_rejected.err
+++ b/tests/compile_fail/083_dynamic_value_cast_rejected.err
@@ -1,0 +1,1 @@
+Cannot cast v to a number: v's type is only known at runtime, and casting a dynamically-tagged value is not currently supported by the compiler

--- a/tests/compile_fail/083_dynamic_value_cast_rejected.vox
+++ b/tests/compile_fail/083_dynamic_value_cast_rejected.vox
@@ -1,0 +1,3 @@
+a value called v is 5.
+a number called z is v as a number add 1.
+Print "z={z}".

--- a/tests/p294_type_lock.rs
+++ b/tests/p294_type_lock.rs
@@ -12,6 +12,7 @@
 // here rather than only as a silent behavior change.
 
 use std::fs;
+use std::os::unix::process::ExitStatusExt;
 use std::process::{Command, Stdio};
 
 fn work_dir(tag: &str) -> std::path::PathBuf {
@@ -211,4 +212,106 @@ For each item in nums,
 "#,
     );
     run_and_expect(&bin, "2\n4\n6\n");
+}
+
+/// A homogeneous map's value type is proven from its own literal (findings
+/// 4, 14) - a same-typed read into an already-declared variable, and a
+/// cast on the read value directly, must both keep working. The cast case
+/// matters specifically: it is the escape hatch `check_type_lock`'s "help:"
+/// line suggests for a mismatched map read, and unlike a `value`-typed
+/// source (see `dynamic_value_cast_is_rejected_not_silently_wrong` below)
+/// this one is proven to actually work, because the map's value type is
+/// statically known here - it never goes through the broken runtime-tag
+/// dispatch at all.
+#[test]
+fn homogeneous_map_value_read_and_cast_still_work() {
+    let work = work_dir("map-homogeneous");
+
+    let bin = compile(
+        &work,
+        "a map called m is {\"k\": 42}.\na number called n is 0.\nn is m's \"k\".\nPrint \"{n}\".\n",
+    );
+    run_and_expect(&bin, "42\n");
+
+    let bin = compile(
+        &work,
+        "a map called m is {\"k\": 42}.\na text called s is \"hello\".\ns is m's \"k\" as text.\nPrint \"[{s}]\".\n",
+    );
+    run_and_expect(&bin, "[42]\n");
+}
+
+/// A map literal with mixed value types (or a non-literal initializer) is
+/// NOT proven, so a read from it is unaffected by findings 4/14's fix - for
+/// better AND worse. This test pins the "worse": reading a key whose OWN
+/// value is a number, from a map that merely CONTAINS some other,
+/// differently-typed key too, into an already-declared text variable,
+/// still compiles and then SEGFAULTS - identical to finding 4's own
+/// mechanism, just reached through a map my single-pass, whole-map
+/// classifier can't prove homogeneous even though this specific key is
+/// perfectly consistent every time it's read. Confirmed unaffected by this
+/// track (same crash before and after `map_value_type` existed) - a real,
+/// known, and explicitly out-of-scope gap: closing it needs PER-KEY value
+/// tracking, not just per-map, which map_literal_value_type deliberately
+/// does not attempt (see its doc comment).
+#[test]
+fn heterogeneous_map_value_read_still_crashes_a_known_gap() {
+    let work = work_dir("map-heterogeneous");
+    let vox = env!("CARGO_BIN_EXE_vox");
+    fs::write(
+        work.join("prog.vox"),
+        "a map called m is {\"k\": 42, \"j\": \"text\"}.\na text called s is \"hello\".\ns is m's \"k\".\nPrint \"[{s}]\".\n",
+    )
+    .unwrap();
+    let bin = work.join("prog");
+    let compile_output = Command::new(vox)
+        .arg(work.join("prog.vox"))
+        .arg("-o")
+        .arg(&bin)
+        .current_dir(&work)
+        .output()
+        .expect("spawn vox");
+    assert!(compile_output.status.success(), "expected this to still compile (unproven, so permitted)");
+    let run_output = Command::new(&bin)
+        .stdin(Stdio::null())
+        .output()
+        .expect("run compiled binary");
+    assert_eq!(
+        run_output.status.signal(),
+        Some(11), // SIGSEGV
+        "expected the pre-existing SIGSEGV this track does not close for a mixed-value map; \
+         got status {:?} - if this now passes, map value inference has grown per-key tracking and \
+         this test (and its documented limitation) should be updated, not just loosened",
+        run_output.status
+    );
+}
+
+/// Casting a `value` whose runtime tag is only known dynamically is
+/// rejected at compile time rather than silently computing garbage - the
+/// "finding 21" gap a review caught: the arithmetic error's hint (fixed in
+/// this track) says to convert with `as a number`/`as text`, and casting a
+/// dynamically-tagged source used to silently pass its raw bytes through
+/// unconverted instead of actually converting them (correct only by
+/// coincidence, when the runtime tag already matched the target's native
+/// representation - wrong, silently, whenever it didn't). See
+/// tests/compile_fail/083_* for the message.
+#[test]
+fn dynamic_value_cast_is_rejected_not_silently_wrong() {
+    let work = work_dir("dynamic-cast-rejected");
+    let vox = env!("CARGO_BIN_EXE_vox");
+    fs::write(
+        work.join("prog.vox"),
+        "a value called v is 5.\na number called z is v as a number add 1.\nPrint \"z={z}\".\n",
+    )
+    .unwrap();
+    let output = Command::new(vox)
+        .arg(work.join("prog.vox"))
+        .arg("-o")
+        .arg(work.join("prog"))
+        .current_dir(&work)
+        .output()
+        .expect("spawn vox");
+    assert!(
+        !output.status.success(),
+        "expected a compile error, but it compiled successfully"
+    );
 }

--- a/tests/p294_type_lock.rs
+++ b/tests/p294_type_lock.rs
@@ -1,0 +1,214 @@
+// Plan 294 — a variable's type is fixed at its declaration and never
+// changes; a type-differing write is a compile error with an explicit-cast
+// suggestion, instead of the compiler's tracked type silently drifting from
+// the variable's actual runtime type (which is what the whole "wrong number
+// printed" / "segfault" bug family came from - see
+// docs/plans/294_retype_audit.md for the full audit and finding list).
+//
+// The negative cases (a type-differing write IS a compile error) are
+// covered by tests/compile_fail/073-080_*. This file covers the positive
+// cases: constructs that must keep compiling and behaving exactly as
+// before, so a narrowing of the rule's scope shows up as a test failure
+// here rather than only as a silent behavior change.
+
+use std::fs;
+use std::process::{Command, Stdio};
+
+fn work_dir(tag: &str) -> std::path::PathBuf {
+    let work = std::env::temp_dir().join(format!("vox-p294-{}-{}", tag, std::process::id()));
+    let _ = fs::remove_dir_all(&work);
+    fs::create_dir_all(&work).expect("create temp work dir");
+    work
+}
+
+fn compile(work: &std::path::Path, source: &str) -> std::path::PathBuf {
+    fs::write(work.join("prog.vox"), source).expect("write prog.vox");
+    let vox = env!("CARGO_BIN_EXE_vox");
+    let bin = work.join("prog");
+    let output = Command::new(vox)
+        .arg(work.join("prog.vox"))
+        .arg("-o")
+        .arg(&bin)
+        .current_dir(work)
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .output()
+        .expect("spawn vox");
+    assert!(
+        output.status.success(),
+        "compile failed; stderr:\n{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    bin
+}
+
+fn run_and_expect(bin: &std::path::Path, expected_stdout: &str) {
+    let output = Command::new(bin)
+        .stdin(Stdio::null())
+        .output()
+        .expect("run compiled binary");
+    assert!(
+        output.status.success(),
+        "program should exit cleanly, got status {:?}; stderr:\n{}",
+        output.status,
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert_eq!(
+        String::from_utf8_lossy(&output.stdout),
+        expected_stdout,
+        "stdout mismatch"
+    );
+}
+
+/// The plan 293 headline segfault (finding 6) is now a compile error, not
+/// a runtime crash. See tests/compile_fail/073_* for the message itself;
+/// this asserts the OLD behavior (compiling and segfaulting) is gone.
+#[test]
+fn plan_293_headline_segfault_is_now_a_compile_error() {
+    let work = work_dir("p293-headline");
+    let vox = env!("CARGO_BIN_EXE_vox");
+    fs::write(
+        work.join("prog.vox"),
+        r#"a number called n is 5.
+a number called g is 0.
+If g is equal to 1,
+  n is "abc".
+Print "{n}".
+"#,
+    )
+    .unwrap();
+    let output = Command::new(vox)
+        .arg(work.join("prog.vox"))
+        .arg("-o")
+        .arg(work.join("prog"))
+        .current_dir(&work)
+        .output()
+        .expect("spawn vox");
+    assert!(
+        !output.status.success(),
+        "expected a compile error, but it compiled successfully"
+    );
+    assert!(
+        !work.join("prog").exists(),
+        "no binary should have been produced"
+    );
+}
+
+/// All three retype spellings agree once an explicit cast is used - the
+/// sanctioned escape hatch the whole rule depends on, both directions.
+#[test]
+fn explicit_cast_works_both_directions_all_three_spellings() {
+    let work = work_dir("explicit-cast");
+
+    let bin = compile(&work, "a number called n is 5.\nn is \"abc\" as a number.\nPrint \"{n}\".\n");
+    run_and_expect(&bin, "0\n");
+
+    let bin = compile(&work, "a number called n is 5.\nthe n is \"42\" as a number.\nPrint \"{n}\".\n");
+    run_and_expect(&bin, "42\n");
+
+    let bin = compile(&work, "a text called s is \"hello\".\nSet s to 42 as text.\nPrint \"{s}\".\n");
+    run_and_expect(&bin, "42\n");
+}
+
+/// A fresh `Set x to <value>` naming a brand-new variable is a genuine
+/// declaration, not a locked rebind - it must keep working exactly as
+/// before this track (only an already-declared name's type is locked).
+///
+/// Uses an integer literal deliberately, not a text one: a fresh `Set n to
+/// "abc".` (n never declared before) is a SEPARATE, pre-existing codegen
+/// bug independent of this track - codegen's `VarDecl` arm only tracks
+/// `variable_types` for a `var_type: None` declaration when the value is
+/// one of a few specific expression shapes (list literal, float literal,
+/// an inherited-from-variable source, ...); a bare string literal matches
+/// none of them, so the fresh slot's type is never recorded and `Print`
+/// reads it as an untyped raw integer instead of following it as a string
+/// pointer. Confirmed present on unmodified `main` (`git diff 409bd2c --
+/// src/codegen/mod.rs` is empty - this file is untouched by plan 294) and
+/// out of scope for this track, which is about REJECTING a conflicting
+/// REBIND, not about a first declaration's value never being tracked at
+/// all. Reported separately rather than fixed here.
+#[test]
+fn set_still_declares_a_new_variable() {
+    let work = work_dir("fresh-decl");
+    let bin = compile(&work, "Set n to 42.\nPrint \"{n}\".\n");
+    run_and_expect(&bin, "42\n");
+}
+
+/// Buffers are exempt from the lock: writing into one is a content/format
+/// operation (copy the value's text into the buffer), not a retype, for
+/// every spelling that writes to one.
+#[test]
+fn buffer_targets_are_exempt_from_the_lock() {
+    let work = work_dir("buffer-exempt");
+
+    let bin = compile(
+        &work,
+        "a buffer called b is 64 bytes in size.\nb is 7.\nb is 123.\nPrint b.\n",
+    );
+    run_and_expect(&bin, "123\n");
+
+    let bin = compile(
+        &work,
+        "a buffer called out is \"\".\nset out to \"N={1 add 1}\".\nprint out.\n",
+    );
+    run_and_expect(&bin, "N=2\n");
+}
+
+/// `value`-typed variables keep accepting any type across reassignment -
+/// that mechanism is the sanctioned dynamic escape hatch and is
+/// unaffected by the lock (plan 294 decision 4).
+#[test]
+fn value_typed_variable_keeps_accepting_varying_types() {
+    let work = work_dir("value-dynamic");
+    let bin = compile(
+        &work,
+        r#"a value called v is 5.
+Print "{v}".
+v is "abc".
+Print "{v}".
+"#,
+    );
+    run_and_expect(&bin, "5\nabc\n");
+}
+
+/// Incrementing a `value` holding a number must keep working - a
+/// regression a review caught mid-track (commit f3ff0be rejected this
+/// before it was reverted). Only Increment/Decrement on TEXT is rejected
+/// (findings 5, 15; see tests/compile_fail/077-078_*).
+#[test]
+fn increment_on_value_typed_number_still_works() {
+    let work = work_dir("value-increment");
+    let bin = compile(&work, "a value called v is 5.\nIncrement v.\nPrint \"{v}\".\n");
+    run_and_expect(&bin, "6\n");
+}
+
+/// A for-range loop variable, freshly introduced, still just works - the
+/// lock (finding 2) only rejects REUSING an already-declared, incompatibly
+/// typed name.
+#[test]
+fn for_range_fresh_loop_variable_still_works() {
+    let work = work_dir("forrange-fresh");
+    let bin = compile(
+        &work,
+        "For each i from 1 to 3,\n  Print \"{i}\".\n",
+    );
+    run_and_expect(&bin, "1\n2\n3\n");
+}
+
+/// Arithmetic on a for-each loop variable over a HOMOGENEOUS list must
+/// keep working without any cast/check - only a list PROVEN heterogeneous
+/// (finding 18; tests/compile_fail/080_*) requires one.
+#[test]
+fn for_each_over_homogeneous_list_arithmetic_still_works() {
+    let work = work_dir("foreach-homogeneous");
+    let bin = compile(
+        &work,
+        r#"a list called nums is [1, 2, 3].
+For each item in nums,
+  a number called doubled is item multiply 2,
+  Print "{doubled}".
+"#,
+    );
+    run_and_expect(&bin, "2\n4\n6\n");
+}

--- a/tests/retype_audit_pocs/01-set-number-into-text-var-segv/poc.sh
+++ b/tests/retype_audit_pocs/01-set-number-into-text-var-segv/poc.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+# CRITICAL: 'Set X to <number>' on a text variable leaves it tracked as text -> SIGSEGV
+# Exits 0 iff the bug is present. See docs/plans/294_retype_audit.md.
+. "$(dirname "$0")/../lib.sh"
+poc_run "$(dirname "$0")/repro.vox"
+poc_expect_segv

--- a/tests/retype_audit_pocs/01-set-number-into-text-var-segv/repro.vox
+++ b/tests/retype_audit_pocs/01-set-number-into-text-var-segv/repro.vox
@@ -1,0 +1,3 @@
+a text called s is "hello".
+Set s to 5.
+Print "{s}".

--- a/tests/retype_audit_pocs/02-forrange-loopvar-reuses-text-name-segv/poc.sh
+++ b/tests/retype_audit_pocs/02-forrange-loopvar-reuses-text-name-segv/poc.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+# CRITICAL: for-range loop variable reusing a text name; codegen never retypes it -> SIGSEGV
+# Exits 0 iff the bug is present. See docs/plans/294_retype_audit.md.
+. "$(dirname "$0")/../lib.sh"
+poc_run "$(dirname "$0")/repro.vox"
+poc_expect_segv

--- a/tests/retype_audit_pocs/02-forrange-loopvar-reuses-text-name-segv/repro.vox
+++ b/tests/retype_audit_pocs/02-forrange-loopvar-reuses-text-name-segv/repro.vox
@@ -1,0 +1,3 @@
+a text called i is "hello".
+For each i from 1 to 3,
+  Print "in {i}".

--- a/tests/retype_audit_pocs/03-fileopen-name-reuses-text-name-segv/poc.sh
+++ b/tests/retype_audit_pocs/03-fileopen-name-reuses-text-name-segv/poc.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+# CRITICAL: 'open a file ... called X' over an existing text name stores an fd but keeps text tracking -> SIGSEGV
+# Exits 0 iff the bug is present. See docs/plans/294_retype_audit.md.
+. "$(dirname "$0")/../lib.sh"
+poc_run "$(dirname "$0")/repro.vox"
+poc_expect_segv

--- a/tests/retype_audit_pocs/03-fileopen-name-reuses-text-name-segv/repro.vox
+++ b/tests/retype_audit_pocs/03-fileopen-name-reuses-text-name-segv/repro.vox
@@ -1,0 +1,3 @@
+a text called src is "hello".
+open a file for reading called src at "/etc/hostname".
+Print "[{src}]".

--- a/tests/retype_audit_pocs/04-map-numeric-value-into-text-var-segv/poc.sh
+++ b/tests/retype_audit_pocs/04-map-numeric-value-into-text-var-segv/poc.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+# CRITICAL: text variable assigned a numeric map value keeps text tracking -> SIGSEGV
+# Exits 0 iff the bug is present. See docs/plans/294_retype_audit.md.
+. "$(dirname "$0")/../lib.sh"
+poc_run "$(dirname "$0")/repro.vox"
+poc_expect_segv

--- a/tests/retype_audit_pocs/04-map-numeric-value-into-text-var-segv/repro.vox
+++ b/tests/retype_audit_pocs/04-map-numeric-value-into-text-var-segv/repro.vox
@@ -1,0 +1,4 @@
+a map called m is {"k": 42}.
+a text called s is "hello".
+s is m's "k".
+Print "[{s}]".

--- a/tests/retype_audit_pocs/05-increment-text-walks-off-map-segv/poc.sh
+++ b/tests/retype_audit_pocs/05-increment-text-walks-off-map-segv/poc.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+# CRITICAL: Increment on a text-tracked variable does raw pointer arithmetic; enough of them leave the mapping -> SIGSEGV
+# Exits 0 iff the bug is present. See docs/plans/294_retype_audit.md.
+. "$(dirname "$0")/../lib.sh"
+poc_run "$(dirname "$0")/repro.vox"
+poc_expect_segv

--- a/tests/retype_audit_pocs/05-increment-text-walks-off-map-segv/repro.vox
+++ b/tests/retype_audit_pocs/05-increment-text-walks-off-map-segv/repro.vox
@@ -1,0 +1,5 @@
+a text called s is "hi".
+Repeat 200000 times,
+  Increment s.
+
+Print "[{s}]".

--- a/tests/retype_audit_pocs/06-untaken-if-branch-segv/poc.sh
+++ b/tests/retype_audit_pocs/06-untaken-if-branch-segv/poc.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+# CRITICAL: assignment in an untaken If branch permanently retypes the variable (Bug A, plan 293) -> SIGSEGV
+# Exits 0 iff the bug is present. See docs/plans/294_retype_audit.md.
+. "$(dirname "$0")/../lib.sh"
+poc_run "$(dirname "$0")/repro.vox"
+poc_expect_segv

--- a/tests/retype_audit_pocs/06-untaken-if-branch-segv/repro.vox
+++ b/tests/retype_audit_pocs/06-untaken-if-branch-segv/repro.vox
@@ -1,0 +1,5 @@
+a number called n is 5.
+a number called g is 0.
+If g is equal to 1,
+  n is "abc".
+Print "{n}".

--- a/tests/retype_audit_pocs/07-untaken-otherwise-branch-segv/poc.sh
+++ b/tests/retype_audit_pocs/07-untaken-otherwise-branch-segv/poc.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+# CRITICAL: assignment in an untaken Otherwise branch retypes the variable -> SIGSEGV
+# Exits 0 iff the bug is present. See docs/plans/294_retype_audit.md.
+. "$(dirname "$0")/../lib.sh"
+poc_run "$(dirname "$0")/repro.vox"
+poc_expect_segv

--- a/tests/retype_audit_pocs/07-untaken-otherwise-branch-segv/repro.vox
+++ b/tests/retype_audit_pocs/07-untaken-otherwise-branch-segv/repro.vox
@@ -1,0 +1,7 @@
+a number called n is 5.
+a number called g is 1.
+If g is equal to 1,
+  Print "taken".
+Otherwise,
+  n is "abc".
+Print "{n}".

--- a/tests/retype_audit_pocs/08-while-body-never-runs-segv/poc.sh
+++ b/tests/retype_audit_pocs/08-while-body-never-runs-segv/poc.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+# CRITICAL: assignment in a While body that never executes retypes the variable -> SIGSEGV
+# Exits 0 iff the bug is present. See docs/plans/294_retype_audit.md.
+. "$(dirname "$0")/../lib.sh"
+poc_run "$(dirname "$0")/repro.vox"
+poc_expect_segv

--- a/tests/retype_audit_pocs/08-while-body-never-runs-segv/repro.vox
+++ b/tests/retype_audit_pocs/08-while-body-never-runs-segv/repro.vox
@@ -1,0 +1,5 @@
+a number called n is 5.
+a number called g is 0.
+While g is equal to 1,
+  n is "abc".
+Print "{n}".

--- a/tests/retype_audit_pocs/09-repeat-zero-times-segv/poc.sh
+++ b/tests/retype_audit_pocs/09-repeat-zero-times-segv/poc.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+# CRITICAL: assignment in a 'Repeat 0 times' body retypes the variable -> SIGSEGV
+# Exits 0 iff the bug is present. See docs/plans/294_retype_audit.md.
+. "$(dirname "$0")/../lib.sh"
+poc_run "$(dirname "$0")/repro.vox"
+poc_expect_segv

--- a/tests/retype_audit_pocs/09-repeat-zero-times-segv/repro.vox
+++ b/tests/retype_audit_pocs/09-repeat-zero-times-segv/repro.vox
@@ -1,0 +1,5 @@
+a number called n is 5.
+Repeat 0 times,
+  n is "abc".
+
+Print "[{n}]".

--- a/tests/retype_audit_pocs/10-forrange-empty-range-segv/poc.sh
+++ b/tests/retype_audit_pocs/10-forrange-empty-range-segv/poc.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+# CRITICAL: assignment in a for-range body over an empty range retypes the variable -> SIGSEGV
+# Exits 0 iff the bug is present. See docs/plans/294_retype_audit.md.
+. "$(dirname "$0")/../lib.sh"
+poc_run "$(dirname "$0")/repro.vox"
+poc_expect_segv

--- a/tests/retype_audit_pocs/10-forrange-empty-range-segv/repro.vox
+++ b/tests/retype_audit_pocs/10-forrange-empty-range-segv/repro.vox
@@ -1,0 +1,4 @@
+a number called n is 5.
+For each k from 1 to 0,
+  n is "abc".
+Print "[{n}]".

--- a/tests/retype_audit_pocs/11-on-error-never-fires-segv/poc.sh
+++ b/tests/retype_audit_pocs/11-on-error-never-fires-segv/poc.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+# CRITICAL: assignment in an 'on error' handler that never fires retypes the variable -> SIGSEGV
+# Exits 0 iff the bug is present. See docs/plans/294_retype_audit.md.
+. "$(dirname "$0")/../lib.sh"
+poc_run "$(dirname "$0")/repro.vox"
+poc_expect_segv

--- a/tests/retype_audit_pocs/11-on-error-never-fires-segv/repro.vox
+++ b/tests/retype_audit_pocs/11-on-error-never-fires-segv/repro.vox
@@ -1,0 +1,5 @@
+a number called n is 5.
+open a file for reading called src at "/etc/hostname".
+on error n is "abc".
+
+Print "[{n}]".

--- a/tests/retype_audit_pocs/12-untaken-branch-declaration-segv/poc.sh
+++ b/tests/retype_audit_pocs/12-untaken-branch-declaration-segv/poc.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+# CRITICAL: a DECLARATION (not assignment) in an untaken branch retypes the outer variable -> SIGSEGV
+# Exits 0 iff the bug is present. See docs/plans/294_retype_audit.md.
+. "$(dirname "$0")/../lib.sh"
+poc_run "$(dirname "$0")/repro.vox"
+poc_expect_segv

--- a/tests/retype_audit_pocs/12-untaken-branch-declaration-segv/repro.vox
+++ b/tests/retype_audit_pocs/12-untaken-branch-declaration-segv/repro.vox
@@ -1,0 +1,5 @@
+a number called n is 5.
+If 1 is equal to 2,
+  a text called n is "abc".
+
+Print "outer [{n}]".

--- a/tests/retype_audit_pocs/13-set-text-into-number-var-wrong-output/poc.sh
+++ b/tests/retype_audit_pocs/13-set-text-into-number-var-wrong-output/poc.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+# HIGH: 'Set X to <text>' updates the value but not the tracked type -> prints the pointer as an integer (Bug B)
+# Exits 0 iff the bug is present. See docs/plans/294_retype_audit.md.
+. "$(dirname "$0")/../lib.sh"
+poc_run "$(dirname "$0")/repro.vox"
+poc_expect_not "abc"

--- a/tests/retype_audit_pocs/13-set-text-into-number-var-wrong-output/repro.vox
+++ b/tests/retype_audit_pocs/13-set-text-into-number-var-wrong-output/repro.vox
@@ -1,0 +1,3 @@
+a number called n is 5.
+Set n to "abc".
+Print "{n}".

--- a/tests/retype_audit_pocs/14-map-text-value-into-number-var-wrong-output/poc.sh
+++ b/tests/retype_audit_pocs/14-map-text-value-into-number-var-wrong-output/poc.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+# HIGH: number variable assigned a text map value keeps integer tracking -> prints the pointer as an integer
+# Exits 0 iff the bug is present. See docs/plans/294_retype_audit.md.
+. "$(dirname "$0")/../lib.sh"
+poc_run "$(dirname "$0")/repro.vox"
+poc_expect_not "abc"

--- a/tests/retype_audit_pocs/14-map-text-value-into-number-var-wrong-output/repro.vox
+++ b/tests/retype_audit_pocs/14-map-text-value-into-number-var-wrong-output/repro.vox
@@ -1,0 +1,4 @@
+a map called m is {"k": "abc"}.
+a number called n is 5.
+n is m's "k".
+Print "{n}".

--- a/tests/retype_audit_pocs/15-decrement-text-oob-read/poc.sh
+++ b/tests/retype_audit_pocs/15-decrement-text-oob-read/poc.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+# HIGH: Decrement on a text-tracked variable moves the pointer before the string and reads out of bounds
+# Exits 0 iff the bug is present. See docs/plans/294_retype_audit.md.
+. "$(dirname "$0")/../lib.sh"
+poc_run "$(dirname "$0")/repro.vox"
+poc_expect_not "[hello]"

--- a/tests/retype_audit_pocs/15-decrement-text-oob-read/repro.vox
+++ b/tests/retype_audit_pocs/15-decrement-text-oob-read/repro.vox
@@ -1,0 +1,3 @@
+a text called s is "hello".
+Decrement s.
+Print "[{s}]".

--- a/tests/retype_audit_pocs/16-set-retype-spurious-arithmetic-error/poc.sh
+++ b/tests/retype_audit_pocs/16-set-retype-spurious-arithmetic-error/poc.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+# MEDIUM: after 'Set X to <number>' retypes a text variable at runtime, the analyzer still calls it text and rejects valid arithmetic
+# Exits 0 iff the bug is present. See docs/plans/294_retype_audit.md.
+. "$(dirname "$0")/../lib.sh"
+poc_run "$(dirname "$0")/repro.vox"
+poc_expect_compile_error "Cannot use text s in arithmetic"

--- a/tests/retype_audit_pocs/16-set-retype-spurious-arithmetic-error/repro.vox
+++ b/tests/retype_audit_pocs/16-set-retype-spurious-arithmetic-error/repro.vox
@@ -1,0 +1,5 @@
+a text called s is "hello".
+Set s to 7.
+a number called z is 0.
+z is s add 1.
+Print "{z}".

--- a/tests/retype_audit_pocs/17-allocate-over-text-name-stale-string/poc.sh
+++ b/tests/retype_audit_pocs/17-allocate-over-text-name-stale-string/poc.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+# LOW: 'Allocate N for X' over a text name drops the analyzer label but leaves codegen tracking it as text
+# Exits 0 iff the bug is present. See docs/plans/294_retype_audit.md.
+. "$(dirname "$0")/../lib.sh"
+poc_run "$(dirname "$0")/repro.vox"
+poc_expect_empty_output

--- a/tests/retype_audit_pocs/17-allocate-over-text-name-stale-string/repro.vox
+++ b/tests/retype_audit_pocs/17-allocate-over-text-name-stale-string/repro.vox
@@ -1,0 +1,3 @@
+a text called p is "hello".
+Allocate 100 for p.
+Print "{p}".

--- a/tests/retype_audit_pocs/18-mixed-list-loopvar-arithmetic/poc.sh
+++ b/tests/retype_audit_pocs/18-mixed-list-loopvar-arithmetic/poc.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+# HIGH: arithmetic on a for-each loop variable over a HETEROGENEOUS list does
+# not dispatch on the element's runtime tag - the text element's pointer is
+# used as an integer operand. Printing the same variable DOES dispatch on the
+# tag and is correct, which is what makes this easy to miss.
+#
+# Exits 0 iff the bug is present. See docs/plans/294_retype_audit.md.
+#
+# Symptom: the second iteration prints a pointer-sized integer. No correct
+# behaviour produces that - a fix either rejects the program at compile time
+# (poc_run reports the compile failure, and we exit 1) or produces a value
+# derived from the text element rather than its address.
+. "$(dirname "$0")/../lib.sh"
+poc_run "$(dirname "$0")/repro.vox"
+
+if [ "$POC_CRC" -ne 0 ]; then
+    echo "NOT REPRODUCED: program no longer compiles (rc=$POC_CRC)"
+    echo "$POC_COUT" | head -5
+    exit 1
+fi
+if [ "$POC_RRC" -ne 0 ]; then
+    echo "REPRODUCED (worse): program crashed, exit=$POC_RRC"
+    exit 0
+fi
+
+first=$(echo "$POC_OUT" | sed -n 1p)
+second=$(echo "$POC_OUT" | sed -n 2p)
+
+# The numeric element must still work; if it does not, this PoC is measuring
+# something else and should not silently claim the bug.
+if [ "$first" != "z=43" ]; then
+    echo "INCONCLUSIVE: expected first line 'z=43', got '$first'"
+    exit 1
+fi
+if echo "$second" | grep -qE '^z=[0-9]{5,}$'; then
+    echo "REPRODUCED: text element's pointer used as an integer operand -> '$second'"
+    exit 0
+fi
+echo "NOT REPRODUCED: second line is '$second'"
+exit 1

--- a/tests/retype_audit_pocs/18-mixed-list-loopvar-arithmetic/repro.vox
+++ b/tests/retype_audit_pocs/18-mixed-list-loopvar-arithmetic/repro.vox
@@ -1,0 +1,4 @@
+a list called data is [42, "hello"].
+For each item in data,
+  a number called z is item add 1,
+  Print "z={z}".

--- a/tests/retype_audit_pocs/21-dynamic-value-cast-silent-garbage/poc.sh
+++ b/tests/retype_audit_pocs/21-dynamic-value-cast-silent-garbage/poc.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+# HIGH: casting a `value` whose runtime tag is only known dynamically (here,
+# from a map read) does not dispatch on the tag - the raw payload (a string
+# pointer) is passed through unconverted instead of being parsed, so it
+# prints as a large, address-shaped integer instead of the atoi("hello")=0 a
+# real conversion would give. Discovered while verifying finding 18's fix
+# (routing a heterogeneous-list loop variable into the same `value`
+# mechanism) actually has a working escape hatch - it didn't, because THIS
+# was already broken underneath it, for any dynamically-tagged `value`, not
+# just loop variables. See docs/plans/294_retype_audit.md, finding 21.
+# Exits 0 iff the bug is present (compiles AND silently computes garbage).
+. "$(dirname "$0")/../lib.sh"
+poc_run "$(dirname "$0")/repro.vox"
+poc_expect_not "z=0"

--- a/tests/retype_audit_pocs/21-dynamic-value-cast-silent-garbage/repro.vox
+++ b/tests/retype_audit_pocs/21-dynamic-value-cast-silent-garbage/repro.vox
@@ -1,0 +1,4 @@
+a map called m is {"k": "hello"}.
+a value called v is m's "k".
+a number called z is v as a number.
+Print "z={z}".

--- a/tests/retype_audit_pocs/lib.sh
+++ b/tests/retype_audit_pocs/lib.sh
@@ -1,0 +1,122 @@
+# Shared helpers for the plan 294 retype-audit PoCs.
+#
+# CONTRACT: every poc.sh exits 0 if and only if the bug it documents is
+# still present. When the bug is fixed the same script must exit non-zero.
+# That direction is what makes these usable as fix-verification.
+#
+# Exit 3 is reserved for "could not run the experiment at all" (missing
+# compiler, failed temp dir). It is non-zero, so an infrastructure failure
+# never reads as "bug present".
+
+set -u
+
+poc_root() { cd "$(dirname "${BASH_SOURCE[1]}")/../../.." && pwd; }
+
+# Compile+run $1 (a .vox path) in a private temp dir. A compiled Vox program
+# is dropped in the CWD, so this never runs inside the repo.
+# Sets: POC_CRC (compile rc), POC_COUT (compiler output),
+#       POC_RRC (run rc), POC_OUT (program stdout+stderr).
+poc_run() {
+    local src="$1" root vox d
+    root="$(cd "$(dirname "${BASH_SOURCE[1]}")/../../.." && pwd)"
+    vox="$root/target/release/vox"
+    if [ ! -x "$vox" ]; then
+        echo "POC-ERROR: no vox binary at $vox (run: cargo build --release)" >&2
+        exit 3
+    fi
+    d="$(mktemp -d /tmp/voxpoc.XXXXXX)" || { echo "POC-ERROR: mktemp failed" >&2; exit 3; }
+    cp "$src" "$d/p.vox" || { rm -rf "$d"; echo "POC-ERROR: cannot read $src" >&2; exit 3; }
+    # The inner subshell's stderr is discarded so the shell's own
+    # "Segmentation fault (core dumped)" job message does not pollute the
+    # PoC verdict. The child's own stderr is already captured in run.log.
+    (
+        cd "$d" || exit 3
+        "$vox" p.vox -o p.bin > compile.log 2>&1
+        echo "$?" > compile.rc
+        if [ -x ./p.bin ]; then
+            ./p.bin > run.log 2>&1
+            echo "$?" > run.rc
+        else
+            echo "" > run.log
+            echo "-1" > run.rc
+        fi
+    ) 2>/dev/null
+    POC_CRC="$(cat "$d/compile.rc" 2>/dev/null || echo 3)"
+    POC_COUT="$(cat "$d/compile.log" 2>/dev/null || true)"
+    POC_RRC="$(cat "$d/run.rc" 2>/dev/null || echo -1)"
+    POC_OUT="$(cat "$d/run.log" 2>/dev/null || true)"
+    rm -rf "$d"
+}
+
+# Bug present iff the program died on SIGSEGV (128+11).
+poc_expect_segv() {
+    if [ "$POC_CRC" -ne 0 ]; then
+        echo "NOT REPRODUCED: program no longer compiles (rc=$POC_CRC)"
+        echo "$POC_COUT" | head -5
+        exit 1
+    fi
+    if [ "$POC_RRC" -eq 139 ]; then
+        echo "REPRODUCED: SIGSEGV (exit 139) - memory-unsafe type confusion present"
+        exit 0
+    fi
+    echo "NOT REPRODUCED: exit=$POC_RRC output=[$POC_OUT]"
+    exit 1
+}
+
+# Bug present iff the program ran but printed something other than $1.
+poc_expect_not() {
+    local want="$1"
+    if [ "$POC_CRC" -ne 0 ]; then
+        echo "NOT REPRODUCED: program no longer compiles (rc=$POC_CRC)"
+        echo "$POC_COUT" | head -5
+        exit 1
+    fi
+    if [ "$POC_RRC" -ne 0 ]; then
+        echo "REPRODUCED (worse): program crashed, exit=$POC_RRC"
+        exit 0
+    fi
+    if [ "$POC_OUT" = "$want" ]; then
+        echo "NOT REPRODUCED: got the correct output [$want]"
+        exit 1
+    fi
+    echo "REPRODUCED: expected [$want], got [$POC_OUT]"
+    exit 0
+}
+
+# Bug present iff the program printed nothing at all. Used where the stale
+# type makes codegen read a freshly-zeroed allocation as a C string: the
+# empty output IS the symptom. Correct tracking would print the pointer as
+# a number, i.e. something non-empty.
+poc_expect_empty_output() {
+    if [ "$POC_CRC" -ne 0 ]; then
+        echo "NOT REPRODUCED: program no longer compiles (rc=$POC_CRC)"
+        echo "$POC_COUT" | head -5
+        exit 1
+    fi
+    if [ "$POC_RRC" -ne 0 ]; then
+        echo "REPRODUCED (worse): program crashed, exit=$POC_RRC"
+        exit 0
+    fi
+    if [ -z "$POC_OUT" ]; then
+        echo "REPRODUCED: printed nothing - the pointer was rendered as a C string"
+        exit 0
+    fi
+    echo "NOT REPRODUCED: printed [$POC_OUT]"
+    exit 1
+}
+
+# Bug present iff compilation failed with a message matching $1.
+poc_expect_compile_error() {
+    local pat="$1"
+    if [ "$POC_CRC" -eq 0 ]; then
+        echo "NOT REPRODUCED: program compiles now"
+        exit 1
+    fi
+    if echo "$POC_COUT" | grep -qi -- "$pat"; then
+        echo "REPRODUCED: spurious compile error matching [$pat]"
+        exit 0
+    fi
+    echo "NOT REPRODUCED: failed, but not with [$pat]:"
+    echo "$POC_COUT" | head -5
+    exit 1
+}

--- a/vox-vscode/package.json
+++ b/vox-vscode/package.json
@@ -2,7 +2,7 @@
   "name": "vox",
   "displayName": "Vox syntax highlighting",
   "description": "Syntax highlighting for Vox (sentence based code) (.vox files)",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "publisher": "vox-lang",
   "engines": {
     "vscode": "^1.75.0"


### PR DESCRIPTION
## What this fixes

A variable's compiler-tracked type could drift out of agreement with the value
actually stored in its slot. Code generation then acted on the tracked type —
dereferencing an integer as a string pointer, or printing a pointer as a
number. Programs that compiled without a warning would segfault at runtime, or
silently print the wrong answer.

```vox
a number called n is 5.
a number called g is 0.
If g is equal to 1,
  n is "abc".
Print "{n}".
```

This compiled cleanly and segfaulted (exit 139) — even though the branch that
reassigns `n` never runs. Changing `g` to `1` made it print `abc` and exit 0.

18 distinct programs of this shape were confirmed and catalogued; 14 of them
crashed, the rest produced silently wrong output.

## The rule

**A variable's type is fixed at its declaration and never changes.** A write
of a different type is a compile error, not a silent retype:

```
error: cannot assign text to 'n', which is a number
  --> prog.vox:2:1
   |
 2 | n is "abc".
   | ^ this assigns text
   |
  note: 'n' was declared as a number at prog.vox:1:17
  help: convert it explicitly:  n is "abc" as a number.
```

This applies to every construct that binds a name, not only assignment —
`x is v`, `the x is v`, `Set x to v`, `For each`/for-range loop variables,
`open ... called x`, `Allocate ... for x`, and nested declarations that reuse
an outer name.

Because a type can no longer change, it cannot drift out of agreement with
what a variable holds regardless of which branch executed — so the whole
class of untaken-branch crashes is closed structurally rather than
case by case.

Two exemptions, both deliberate: **buffers** (writing into one is a format
operation, not a type change) and **`value`** (the language's dynamic type,
which keeps accepting any type by design).

`Increment`/`Decrement` on a text variable is now rejected too — it did
integer arithmetic on a string pointer, walking off the mapping.

## Migration

A program that previously compiled may now fail to compile. Convert
explicitly using the existing cast syntax:

```vox
a number called n is 5.
n is "abc".              # now a compile error
n is "42" as a number.   # do this instead
```

One file in the repository relied on the old behaviour
(`tests/149_cast_in_arithmetic.vox`) and has been migrated.

## What this does not close

Stated plainly so the guarantee isn't read as wider than it is:

- **Casting a dynamically-tagged `value` cannot convert.** `v as a number`
  where `v`'s type is only known at runtime is now a compile error rather
  than a silent wrong answer — the safe state, but the conversion itself is
  not implemented. Neither does a type-predicate guard narrow the type inside
  its body. There is currently no supported way to convert or narrow such a
  value from within the language.
- **A `.lib`'s declared signature is trusted, not verified against its
  `.so`.** A library declaring a return type its implementation does not
  provide is accepted, and can crash the consumer. Symbol verification cannot
  detect this because the mangled name carries no type information.
- **Map value types are inferred only from a homogeneous literal.** A map
  with mixed value types, no literal, or an empty literal remains unprovable
  and behaves as before.

All three are recorded with reproductions in
`docs/plans/294_retype_audit.md`.

## Changes

- Type immutability enforced across all binding sites, with diagnostics that
  name the variable, its declared type and declaration site, and the exact
  cast that resolves it
- Homogeneous map literals now infer a value type, making mismatched map
  reads a compile error
- Heterogeneous-list loop variables route through the runtime-tagged dynamic
  mechanism and require an explicit check
- `LANGUAGE.md`: new "Type Immutability" section, including what the rule
  does not catch
- `ROADMAP.md`: milestone updated; stale version reference corrected
- Version 0.3.2 → 0.3.3; VS Code extension 0.3.0 → 0.3.1

## Verification

- `cargo test --release`: all binaries green
- `./test.sh`: 219 passed, 0 failed, 6 skipped — including the compile check
  over every file in `examples/`
- All 18 catalogued reproductions no longer reproduce
- `vox-vscode/check-grammar.sh`: 150 lexer keywords, 0 missing, 0
  grammar-only
