### PR TITLE
Full type-vocabulary parity for parameters and return types, and list element typing across the .lib boundary

### DIFF
--- a/LANGUAGE.md
+++ b/LANGUAGE.md
@@ -524,11 +524,14 @@ To 'check divisibility' of a number called divisor and a number called dividend.
 
 ### Parameter and Local Types (v0.1.16)
 
-Parameters may use any variable type, including `buffer`, `list`, `map`,
-and `file` - and a typed parameter supports the same properties and
-operations as a top-level variable of that type. A parameter (or return
-type) may also be `value`, the dynamic type whose runtime tag travels with
-its payload across the call (a map rides this as payload + tag 5); see
+Parameters may use any of the 11 expressible types — `number`, `float`,
+`text`, `boolean`, `list`, `map`, `buffer`, `file`, `time`, `timer`, `value`
+— and a typed parameter supports the same properties and operations as a
+top-level variable of that type. The same 11 types are also legal as a
+declared `Return a <type>,` return type (plan 296) — parameters and returns
+share one vocabulary, not two. A parameter (or return type) may also be
+`value`, the dynamic type whose runtime tag travels with its payload across
+the call (a map rides this as payload + tag 5); see
 [Dynamic Values (`value`)](#dynamic-values-value)
 below.
 
@@ -3160,12 +3163,28 @@ Table of Contents:
   `.lib` first, then `--lib-path`, then error. Absolute paths are honoured but
   never generated, so a `.lib` is portable.
 - **`Table of Contents:`** — one line per exported function, in the same
-  signature vocabulary as Vox source. Parameter and return types are drawn from
-  `number`, `text`, `boolean`, `file`, `value`; anything else is an error
-  naming the unsupported type.
-- **`, returning a <type>`** is new and exists only in `.lib` files. Vox source
-  declares return types in the body (`Return a number, x.`), which a bodiless
-  `.lib` declaration has no room for.
+  11-type vocabulary as Vox source, in EITHER position: `number`, `float`,
+  `text`, `boolean`, `list`, `map`, `buffer`, `file`, `time`, `timer`,
+  `value`; anything else is an error naming the unsupported type. `void`
+  isn't a spelling — a function returning nothing omits the `, returning`
+  clause entirely — and neither is `unknown`, the compiler's own internal
+  placeholder for an untyped parameter.
+- A `list` may optionally carry its element type: `a list of text called
+  out`, `returning a list of text`. This is compiler-inferred, not author-
+  declared — Vox source has no generic/typed-collection syntax, so a library
+  author still just writes `a list called out`; a `--shared` build scans the
+  exported function's own body and, when every appended/returned element
+  provably agrees on one type, writes `list of <type>` for you. Disagreement
+  or no evidence emits plain untyped `list`, same as always. `map`'s value
+  type isn't carried this way; `map` stays element-untyped in both
+  positions.
+- **`, returning a <type>`** exists only in `.lib` files. Vox source declares
+  return types in the body (`Return a number, x.`), which a bodiless `.lib`
+  declaration has no room for. No `returning` clause means the function
+  returns nothing — which is also why a list's element type only shows up in
+  the `.lib` when the exporting function has a *declared* return type
+  (`Return a list, out.`) in the first place; a bare `Return out.` records no
+  return type at all, list-element-typing included.
 
 A `.lib` is lexed with the Vox lexer but parsed by a dedicated parser, so it
 cannot carry executable statements — only the interface above.

--- a/docs/SHARED_LIBRARIES_DESIGN.md
+++ b/docs/SHARED_LIBRARIES_DESIGN.md
@@ -63,13 +63,48 @@ flag, then error. It is relative by norm so a `.lib`/`.so` pair can be moved or
 shipped together; an absolute `Location` is honoured when read but never
 generated.
 
-Parameter and return types are drawn from a fixed vocabulary — `number`,
-`text`, `boolean`, `file`, `value`; anything else is an error naming the
-unsupported type. The `, returning a <type>` suffix exists **only** in `.lib`
-files: a `.lib` entry is a bodiless declaration, so the return type rides the
-signature. In Vox source the return type lives in the body
-(`Return a number, x.`), which a bodiless `.lib` line has no room for. An entry
-with no `returning` clause denotes a function that returns nothing.
+Parameter and return types are drawn from the SAME fixed 11-type vocabulary,
+in EITHER position — `number`, `float`, `text`, `boolean`, `list`, `map`,
+`buffer`, `file`, `time`, `timer`, `value`; anything else is an error naming
+the unsupported type. This mirrors Vox source exactly: every one of these 11
+types is also legal as a `with a <type> called x` parameter and as a
+`Return a <type>,` declared return type on an ordinary function (plan 296).
+
+Two types are deliberately NOT in that list, and never will be:
+
+- **`void`** isn't a spelling — a function that returns nothing is declared
+  by *omitting* the `, returning` clause (`.lib`) or the `Return a <type>,`
+  annotation (Vox source) entirely. There is no `returning a void`.
+- **`unknown`** isn't a spelling either — it's the compiler's own internal
+  placeholder for an untyped `with n` parameter, never something an author
+  writes.
+
+A `list` may optionally carry its element type: `a list of text called out`,
+`returning a list of text`. This is **compiler-inferred, never author-
+declared** — Vox source itself has no generic/typed-collection syntax (a
+library author still just writes `a list called out`); when a `--shared`
+build exports a function with a list parameter or list return, it scans that
+function's own body for `Append`/literal evidence and, when every element
+provably agrees on one type, writes `list of <type>` into the `.lib` for you.
+Disagreement, or no evidence at all, emits plain untyped `list`, exactly as
+before this existed. `map`'s value type is not carried this way — `.lib`
+accepts bare `map` in both positions, element-untyped.
+
+The `, returning a <type>` suffix exists **only** in `.lib` files: a `.lib`
+entry is a bodiless declaration, so the return type rides the signature. In
+Vox source the return type lives in the body (`Return a number, x.`), which a
+bodiless `.lib` line has no room for. An entry with no `returning` clause
+denotes a function that returns nothing — this is also why a `.lib`-exported
+function needs a *declared* return type (`Return a list, out.`, not a bare
+`Return out.`) before the `.lib` can say anything about what it returns at
+all, list-element-typing included.
+
+A `.lib`'s declared types are trusted, not verified against the `.so`'s
+actual behavior (plan 294 findings 19/20): a `.lib` declaring a return type
+its implementation doesn't really provide crashes the consumer. Widening the
+declarable vocabulary (plan 296) widens what a stale or hand-edited `.lib`
+can misdeclare; it does not add any new verification. That remains a known,
+unfixed gap.
 
 ### Library Linking
 

--- a/docs/plans/296_lib_collection_types.md
+++ b/docs/plans/296_lib_collection_types.md
@@ -1,140 +1,278 @@
-# Plan 296 — `list` and `buffer` across the `.lib` boundary: allow them as return types, and carry the element type
+# Plan 296 — full type-vocabulary parity for parameters and return types,
+# on ordinary Vox functions and across the `.lib` boundary
 
-**Status:** specced 2026-08-08. Both halves verified against `23bc193`
-(v0.3.3) by the plan author.
+**Status:** specced 2026-08-08, rescoped 2026-08-09 (two owner steering
+messages, both folded in below). Baseline measurements below are against
+`23bc193` (v0.3.3).
 
-## Two defects, one piece of work
+## Rescope history
 
-A shared library cannot usefully hand a collection back to its caller. There
-are two separate reasons, and **fixing either alone leaves the feature
-broken**, which is why they are one plan.
+The plan started narrow: allow `list`/`buffer` as `.lib` return types, and
+stop erasing a list's element type at the `.lib` boundary. Two owner
+messages widened it during implementation:
 
-### Half 1 — `list`/`buffer` are rejected in return position
+1. **"every type Vox can express must work as a `.lib` PARAMETER and RETURN
+   TYPE. Not a curated subset."** The `.lib` return-type limit (five types)
+   is a bug to delete, not a design to preserve. `float` is missing from the
+   `.lib` vocabulary entirely, in both positions — a second hole in the same
+   wall.
+2. **"this must work for ORDINARY FUNCTIONS too... ordinary functions are
+   the ROOT of the problem."** The `.lib` vocabulary mirrors a restriction
+   that already exists in Vox source's own `Return a <type>,` syntax.
+   Fixing `lib_file.rs` alone would be pointless — a library author cannot
+   write `Return a list, ...` in Vox source in the first place, so there is
+   nothing for a widened `.lib` to describe.
 
-`src/lib_file.rs` accepts them as parameters and only as parameters:
+So the work has two surfaces, not one, and both need the same vocabulary in
+both positions.
 
-```rust
-Token::Buffer if position == "parameter" => Some(Type::Buffer),
-Token::List   if position == "parameter" => Some(Type::List(Box::new(Type::Unknown))),
-```
+## The target vocabulary
 
-A `.lib` declaring `To f, returning a buffer.` is an error, and there is a
-test pinning that behaviour:
+From `src/parser/ast.rs`, `Type` has 13 variants: `Integer, Float, String,
+Boolean, List, Map, Buffer, File, Time, Timer, Value, Void, Unknown`.
 
-```rust
-#[test]
-fn unsupported_return_type_is_named() { /* asserts "unsupported type" and "'buffer'" */ }
-```
+11 of these are expressible and get full parameter/return parity:
+**number, float, text, boolean, list, map, buffer, file, time, timer,
+value.**
 
-That test encodes the restriction this plan removes. **Updating it is expected
-and correct** — do not treat it as a regression, and do not weaken the rest of
-the test around it. If some type genuinely must stay unsupported in return
-position, keep a case asserting *that* type instead, so the "named unsupported
-type" diagnostic still has coverage.
+Two need a judgment call, not blind inclusion:
 
-### Half 2 — the element type is erased at the boundary
+- **`Void`** already means "returns nothing," spelled by *omitting* the
+  `Return`/`, returning` clause entirely. This stays as-is — there is no
+  `returning a void` or `Return a void,`. Adding a spelling for "nothing"
+  would give two ways to say the same thing (omit the clause, or say
+  `void`), which is exactly the kind of surface-area growth this plan is
+  supposed to be closing off, not opening. Not adding it.
+- **`Unknown`** is an internal placeholder — the parser's fallback for an
+  untyped `with n` parameter, and the `.lib` emitter's fallback noun when a
+  parameter has no declared type (`param_type_noun`'s "render `Unknown` as
+  `number`" comment). It has no surface spelling anywhere in Vox source and
+  none is being added: "unknown" is not a type an author declares, it is
+  what's left when they declare nothing.
 
-Even as a parameter, a list crosses with its element type hard-coded to
-`Unknown` (the `Box::new(Type::Unknown)` above). The structure survives; the
-typing does not.
+## Baseline measurements (verify-before-build, both true on `23bc193`)
 
-Verified end to end. Library:
+**A. Vox source `Return a <type>,` accepts 5 of 11, and inconsistently —
+two divergent parsers.** `To 'give it'. Return a <type>, 1.` (Return as the
+function's only/first statement) goes through the *inline* path in
+`parse_function_def` (`src/parser/mod.rs` ~4295-4309):
+accepts number, text, boolean, file, value; rejects float, list, map,
+buffer, time, timer with `Expected a statement, got <Type>`.
 
+But when `Return` is **not** the function's first statement, a *different*
+parser runs — `parse_return` (Gate B, ~2154-2189) — and it is stricter
+still: it accepts only number, text, boolean (file and value fail there
+too, with `Expected type after 'a' in return statement`). This divergence
+between two parsers for the same syntax is itself a bug, and exactly the
+kind of thing a shared vocabulary table (see "What to build") prevents from
+recurring.
+
+**B. The bare (undeclared-type) return already carries collections
+correctly, structurally — but not their elements.**
 ```vox
-Library strkit version "1.0".
+To 'make it'.
+  a list called out is ["a", "b"].
+  Return out.
 
-To 'split into' with a text called s and a list called out.
-  Append s to out.
-  Append "second" to out.
+a list called got is 'make it'.
+Print "len={got's length}".
+For each t from got, print "tok=[{t}]".
 ```
+Verified: `len=2` (structurally correct — the pointer and length cross
+back), but `tok=[4198528]` / `tok=[4198530]` (raw pointers — the element
+type does not cross). This is the SAME element-erasure bug the original
+plan found at the `.lib` boundary, just one level upstream: it already
+happens for an ordinary same-file function returning a list through an
+undeclared `Return`. Confirms the fix target (typed declaration syntax) is
+additive — codegen's calling convention for returning a list is already
+correct; only the declared-type *acceptance* and the element-type
+*propagation* are missing.
 
-Consumer:
+**C. Vox source function PARAMETER declarations (`with a <type> called
+x`) are also missing float/time/timer** (`src/parser/mod.rs` ~4230-4247)
+— confirmed by direct test: `To f with a float called x.` fails with
+"Cannot use 'float' as a variable name," because the unmatched `Token::Float`
+is never consumed and `parse_name()` then trips over it. `list`, `map`,
+`buffer`, `file`, `value` already work as parameters (just untyped-element
+for the collections); this only affects the three newcomers.
 
-```vox
-see strkit version "1.0" from "./libstrkit.lib".
-
-a list called toks is [].
-'split into' with "hello" and toks.
-Print "count={toks's length}".
-For each t from toks, print "tok=[{t}]".
-```
-
-**Actual:**
-
-```
-count=2
-tok=[4206728]
-tok=[139626265276507]
-```
-
-`count=2` is correct — the mutation crosses back, so the out-parameter shape
-genuinely works. But the elements print as raw pointers, because the caller
-has no way to learn they are text. This is the same element-type erasure
-catalogued in plan 294 (findings 4, 14, 18), in a third location.
-
-**A returned list would hit exactly this.** So half 1 without half 2 ships a
-feature whose results are unreadable.
+**D. `.lib` vocabulary today:** parameter position accepts number, text,
+boolean, file, buffer, list, map, value (8; missing float, time, timer).
+Return position accepts only number, text, boolean, file, value (5; missing
+float, list, map, buffer, time, timer). Both gaps mirror A and C — the
+`.lib` format was never ahead of what Vox source could already express, so
+fixing it alone (the original narrow plan) would have described signatures
+no library could implement.
 
 ## What to build
 
-1. **Allow `list` and `buffer` in return position** in `.lib` parse and emit,
-   dropping the `position == "parameter"` guard for these two.
-2. **Carry the element type** for lists across the boundary, in both parameter
-   and return position, so `Type::List(Box::new(Type::Unknown))` becomes the
-   declared element type.
+### 1. Vox source: one shared type-vocabulary table, used by all three
+   parser sites that currently disagree
 
-Half 2 needs a surface syntax for a typed list. **Decide it and say why.** A
-natural candidate is:
+Add a single helper (`fn declaration_type_token(&self) -> Option<Type>` or
+similar) in `src/parser/mod.rs` recognizing all 11 types, and make these
+three sites call it instead of hand-rolling their own `match`:
 
-```
-To 'split into' with a text called s and a list of text called out.
-To 'tokens of' with a text called s, returning a list of text.
-```
+- Function parameter type (`with a <type> called <name>`, ~4230-4247):
+  add float, time, timer (list/map/buffer/file/value already present).
+- `Return a <type>,` inline path (~4295-4309): add float, list, map,
+  buffer, time, timer.
+- `Return a <type>,` Gate-B path (`parse_return`, ~2154-2189): add file,
+  value, float, list, map, buffer, time, timer.
 
-Before designing, establish what Vox source already accepts for a typed list
-parameter — I tried three spellings and all three were rejected, but my test
-harness also rejected the plain `a list called out` form that demonstrably
-works, so **that test was broken and proves nothing**. Find out for real. If
-Vox source has no typed-list syntax at all, then this plan needs it in the
-language, not only in `.lib`, and that is a bigger decision — stop and tell me
-rather than inventing `.lib`-only syntax that source cannot express.
+One shared table is the actual fix for "never wants to hear about this
+class of problem again" — baseline A exists *because* two call sites hand-
+rolled the same vocabulary and drifted. A third divergent copy is not
+an option.
 
-Keep backward compatibility: an untyped `a list called out` in an existing
-`.lib` must keep parsing, with the element type unknown as today.
+`list`/`map` stay element-untyped at the Vox-source declaration syntax
+level (`Type::List(Box::new(Type::Unknown))`) — Vox deliberately has no
+generic/typed-collection declaration syntax; see "Element typing" below for
+why that's the right boundary and how the `.lib` case differs.
+
+### 2. `.lib`: the same 11-type vocabulary, in both positions
+
+`src/lib_file.rs`, `take_type`: add float/time/timer (new to both
+positions), and drop the `position == "parameter"` guard on buffer/list/map
+so they're legal in return position too. One vocabulary list, one error
+message, no more per-position allow-lists.
+
+`src/codegen/mod.rs`: `param_type_noun`/`return_type_noun` collapse into one
+`type_noun` used for both positions (mirroring the `.lib` parser now
+accepting the same set both ways) — see "Element typing" for the one
+exception (`list`'s optional `of <type>` suffix).
+
+### 3. Element typing still crosses the `.lib` boundary (original plan,
+   unchanged in scope: `list` only, not `map`)
+
+Vox source has **no** typed-list declaration syntax anywhere (confirmed:
+grepped every `Token::List` match in the parser — var decl, parameter,
+`is a list` predicate — all three hard-code
+`Type::List(Box::new(Type::Unknown))`). This is deliberate, not an
+oversight: `docs/COLLECTIONS_ROADMAP.md` states the design principle
+outright — "the author picks the data; the compiler picks the
+representation" — element type is *inferred* from how a list is built
+(first-append/literal), never *declared*. Confirmed live: a list built from
+string literals prints correctly with zero type annotation anywhere in the
+program.
+
+The original plan's stop condition — "if Vox source has no typed-list
+syntax at all... stop and tell me rather than inventing `.lib`-only syntax
+that source cannot express" — is real and was hit. Resolution, restated
+per the owner's follow-up ("element typing must cross the boundary too,
+per the original plan"): the `.lib` does **not** gain author-facing generic
+syntax. Instead:
+
+- **Emit side (Stage A3):** when a `.lib`-exported function has a
+  list-typed parameter or a list-typed return, statically scan that
+  function's own body (parameter appends: `Append <expr> to <param>`;
+  return-traced literals/appends: `Return <list-var>.`) using the same
+  "first-append/literal decides, disagreement widens to untyped" rule the
+  compiler already applies for local list printing. If every observed
+  element is the same scalar type, the `.lib` records it; if the scan finds
+  disagreement or nothing at all, it emits plain untyped `list`, exactly
+  today's behavior. **The library author writes nothing new** — this is a
+  compiler-computed fact serialized into a machine-oriented interface file,
+  the same way a return type is already inferred from the body rather than
+  hand-annotated in the `.so`.
+- **`.lib` serialization spelling (read+write):** `a list of <type> called
+  <name>` / `returning a list of <type>`, where `<type>` is any of the nine
+  non-collection nouns (number, float, text, boolean, file, buffer, time,
+  timer, value — no nested list-of-list/map, out of scope, no evidence
+  requires it). Bare `list` keeps parsing exactly as today (backward
+  compatible; untyped element). This spelling exists **only** in the `.lib`
+  grammar — which is already its own bespoke DSL, not a Vox-source subset
+  (`lib_file.rs`'s own module doc: "parsed by this dedicated parser, not
+  the full Vox parser... deliberate"). It does not imply or require any new
+  Vox author-facing syntax, so it does not contradict the "author doesn't
+  declare, compiler infers" principle above — it just gives the compiler's
+  own inference a place to write its answer down.
+- **Consume side:** at a call site whose target's `.lib`-declared parameter
+  is `list of <type>`, and the argument is a plain local variable, the
+  codegen records that variable's element type the same way a local
+  `Append <literal> to x` already does. Symmetrically, a `VarDecl` whose
+  value is a call to a `.lib` function with a `list of <type>` return
+  records the declared variable's element type. Both are additive lookups
+  keyed off the already-`.dynsym`-verified import table; no new runtime
+  representation, no ABI change — a list crossing the boundary is the exact
+  same pointer it is today, just with the compiler now trusting a real
+  element type for it instead of defaulting to "don't know."
+
+`map`'s value type is **not** addressed here — the original plan never
+scoped it, and the owner's follow-ups reaffirmed "everything else in the
+plan stands" without mentioning it. `.lib` gains bare `map` in return
+position (item 2), but its value type stays `Unknown`, same as today. Noted
+below as a symmetric known gap, not fixed here.
+
+## Newly discovered, explicitly out of scope
+
+**The element-erasure bug is not `.lib`-specific — it also hits an
+ordinary same-file out-parameter and an ordinary same-file undeclared list
+return (baseline B above, and a same-file out-param case verified the same
+way: `To 'fill' with a list called out. Append "hi" to out. ...` — the
+caller's `for each` also prints raw pointers).** Root cause: the compiler's
+existing flow-sensitive list pre-scan (`prescan_walk` /
+`prescan_mixed_lists` in `codegen/mod.rs`) recurses into a function's body
+but never seeds its environment with that function's own **parameters** —
+so any list built through a parameter (appended-to as an out-param, or
+returned after being appended-to) is invisible to the same inference that
+already works for a list built and printed within one straight-line scope.
+This plan does not fix it: the two steering messages scoped element-typing
+fixes to "the boundary" (the `.lib` case) specifically, and a general fix
+to the pre-scan's parameter-seeding is a larger, independent change with
+its own blast radius across every function call in the language, not just
+`.lib` calls. Flagged for a future plan.
+
+**Declared `.lib` types remain trusted, not verified against the `.so`**
+(plan 294 findings 19/20 — a `.lib` declaring a return type its
+implementation doesn't provide crashes the consumer). This plan widens what
+a `.lib` may declare in both positions, which widens that hole further
+(more declarable types = more ways to lie). Not fixed here, per the
+original plan's explicit instruction.
 
 ## Acceptance criteria
 
-1. A library can declare `, returning a list` and `, returning a buffer`, and
-   a consumer can call it and use the result.
-2. The verified repro above prints `tok=[hello]` and `tok=[second]` — real
-   values, not pointers — for the **parameter** case.
-3. The same holds for a **returned** list.
-4. Round trip: emit a `.lib` with these signatures and parse it back
-   (`lib_file.rs` already has round-trip tests; extend them).
-5. `examples/mathkit_lib.vox` and the C-interop test still work — the ABI for
-   existing scalar signatures must not shift.
+1. `Return a <type>, <expr>.` accepts all 11 types, identically via both
+   the inline and Gate-B parser paths, for an ordinary (non-`.lib`) Vox
+   function.
+2. `with a <type> called <name>` accepts all 11 types as an ordinary
+   function parameter.
+3. A `.lib` can declare all 11 types in **both** parameter and return
+   position; round-trips (emit a `.lib`, reparse it, type survives) for
+   every one of the 11, in both positions.
+4. The original verified repro prints `tok=[hello]` / `tok=[second]` (real
+   values) for the **parameter** case, and the analogous **returned**-list
+   case (a `.lib` function returning a list of text, consumed and
+   `for each`-printed) does too.
+5. `examples/mathkit_lib.vox` and the C-interop test still work — the ABI
+   for existing scalar signatures must not shift.
 6. Gate green: `cargo build --release` (0 warnings), `cargo test --release`,
-   `./test.sh` (baseline **219 passed / 0 failed / 6 skipped**, includes a
-   compile check over every file in `examples/`).
+   `./test.sh` (baseline 219 passed / 0 failed / 6 skipped — count will grow
+   with the new matrix tests).
 7. Plan 294 PoCs stay closed: `for d in tests/retype_audit_pocs/[0-9]*/; do
-   bash "$d/poc.sh"; echo "$d -> $?"; done` — all **non-zero**.
+   bash "$d/poc.sh"; echo "$d -> $?"; done` — all non-zero.
+8. Regression matrix tests exist on **both** surfaces (ordinary-function
+   `Return`, and `.lib` parameter+return round trip) covering all 11 types,
+   so a future narrowing on either surface fails a test instead of shipping
+   silently.
+9. `unsupported_return_type_is_named` (the test that pinned the old
+   restriction) is rewritten to assert the "named unsupported type"
+   diagnostic still fires for a genuinely-invalid type (not
+   buffer/list/map/float/time/timer anymore — those are now valid) — the
+   coverage for that diagnostic is not deleted, just re-pointed.
 
-## Documentation — I am auditing this myself, so get it right
+## Documentation — describe the END STATE, not the history
 
-`docs/SHARED_LIBRARIES_DESIGN.md` currently states the vocabulary as
-`number`, `text`, `boolean`, `file`, `value` without distinguishing parameter
-from return position — which is how I got this wrong in the first place.
-Update it to state the rule precisely, per position, after your change.
-I will check it against the code myself and send back anything that does not
-match.
-
-## Known adjacent gap — do NOT fix here
-
-A `.lib`'s declared types are trusted, never verified against the `.so`
-(plan 294 findings 19/20 — a library declaring a return type its
-implementation does not provide crashes the consumer). This plan **widens**
-what a `.lib` may declare, so it widens that hole. Note it in the plan doc as
-a consequence; do not attempt to fix verification here.
+`docs/SHARED_LIBRARIES_DESIGN.md` and `LANGUAGE.md` both currently state a
+single five-type vocabulary shared by parameters and returns. That was
+already wrong (parameters additionally took buffer/list/map/value — 8, not
+5) and becomes wrong in a new way once this lands (11 in both positions).
+Rewrite both to state the finished rule plainly — the same 11-type set in
+both positions, on both ordinary functions and `.lib` — with no "this used
+to be narrower" framing. Also document: the `list of <type>` `.lib`
+spelling and that it's compiler-inferred, never author-declared; that
+`map`'s value type is not carried; and that `Void`/`Unknown` are
+deliberately unspellable (see judgment calls above).
 
 ## Hard constraints
 
@@ -144,11 +282,10 @@ a consequence; do not attempt to fix verification here.
   human.
 - **No `Co-Authored-By:` trailers.**
 - **Do not spawn workers.** You are the worker.
-- Commit incrementally — one commit per half — so I can review as you go.
+- Commit incrementally so the owner can review as you go.
 
 ## Reporting
 
-Report each half: done / not done, with the reason. Say plainly if this brief
-is wrong about the code — I would rather fix the brief than have you build on
-a false premise. Report what you could not do rather than silently reducing
-scope.
+Report each unit of work: done / not done, with the reason. Say plainly if
+this doc is wrong about the code — fixing the doc beats building on a false
+premise. Report what could not be done rather than silently reducing scope.

--- a/docs/plans/296_lib_collection_types.md
+++ b/docs/plans/296_lib_collection_types.md
@@ -1,0 +1,154 @@
+# Plan 296 — `list` and `buffer` across the `.lib` boundary: allow them as return types, and carry the element type
+
+**Status:** specced 2026-08-08. Both halves verified against `23bc193`
+(v0.3.3) by the plan author.
+
+## Two defects, one piece of work
+
+A shared library cannot usefully hand a collection back to its caller. There
+are two separate reasons, and **fixing either alone leaves the feature
+broken**, which is why they are one plan.
+
+### Half 1 — `list`/`buffer` are rejected in return position
+
+`src/lib_file.rs` accepts them as parameters and only as parameters:
+
+```rust
+Token::Buffer if position == "parameter" => Some(Type::Buffer),
+Token::List   if position == "parameter" => Some(Type::List(Box::new(Type::Unknown))),
+```
+
+A `.lib` declaring `To f, returning a buffer.` is an error, and there is a
+test pinning that behaviour:
+
+```rust
+#[test]
+fn unsupported_return_type_is_named() { /* asserts "unsupported type" and "'buffer'" */ }
+```
+
+That test encodes the restriction this plan removes. **Updating it is expected
+and correct** — do not treat it as a regression, and do not weaken the rest of
+the test around it. If some type genuinely must stay unsupported in return
+position, keep a case asserting *that* type instead, so the "named unsupported
+type" diagnostic still has coverage.
+
+### Half 2 — the element type is erased at the boundary
+
+Even as a parameter, a list crosses with its element type hard-coded to
+`Unknown` (the `Box::new(Type::Unknown)` above). The structure survives; the
+typing does not.
+
+Verified end to end. Library:
+
+```vox
+Library strkit version "1.0".
+
+To 'split into' with a text called s and a list called out.
+  Append s to out.
+  Append "second" to out.
+```
+
+Consumer:
+
+```vox
+see strkit version "1.0" from "./libstrkit.lib".
+
+a list called toks is [].
+'split into' with "hello" and toks.
+Print "count={toks's length}".
+For each t from toks, print "tok=[{t}]".
+```
+
+**Actual:**
+
+```
+count=2
+tok=[4206728]
+tok=[139626265276507]
+```
+
+`count=2` is correct — the mutation crosses back, so the out-parameter shape
+genuinely works. But the elements print as raw pointers, because the caller
+has no way to learn they are text. This is the same element-type erasure
+catalogued in plan 294 (findings 4, 14, 18), in a third location.
+
+**A returned list would hit exactly this.** So half 1 without half 2 ships a
+feature whose results are unreadable.
+
+## What to build
+
+1. **Allow `list` and `buffer` in return position** in `.lib` parse and emit,
+   dropping the `position == "parameter"` guard for these two.
+2. **Carry the element type** for lists across the boundary, in both parameter
+   and return position, so `Type::List(Box::new(Type::Unknown))` becomes the
+   declared element type.
+
+Half 2 needs a surface syntax for a typed list. **Decide it and say why.** A
+natural candidate is:
+
+```
+To 'split into' with a text called s and a list of text called out.
+To 'tokens of' with a text called s, returning a list of text.
+```
+
+Before designing, establish what Vox source already accepts for a typed list
+parameter — I tried three spellings and all three were rejected, but my test
+harness also rejected the plain `a list called out` form that demonstrably
+works, so **that test was broken and proves nothing**. Find out for real. If
+Vox source has no typed-list syntax at all, then this plan needs it in the
+language, not only in `.lib`, and that is a bigger decision — stop and tell me
+rather than inventing `.lib`-only syntax that source cannot express.
+
+Keep backward compatibility: an untyped `a list called out` in an existing
+`.lib` must keep parsing, with the element type unknown as today.
+
+## Acceptance criteria
+
+1. A library can declare `, returning a list` and `, returning a buffer`, and
+   a consumer can call it and use the result.
+2. The verified repro above prints `tok=[hello]` and `tok=[second]` — real
+   values, not pointers — for the **parameter** case.
+3. The same holds for a **returned** list.
+4. Round trip: emit a `.lib` with these signatures and parse it back
+   (`lib_file.rs` already has round-trip tests; extend them).
+5. `examples/mathkit_lib.vox` and the C-interop test still work — the ABI for
+   existing scalar signatures must not shift.
+6. Gate green: `cargo build --release` (0 warnings), `cargo test --release`,
+   `./test.sh` (baseline **219 passed / 0 failed / 6 skipped**, includes a
+   compile check over every file in `examples/`).
+7. Plan 294 PoCs stay closed: `for d in tests/retype_audit_pocs/[0-9]*/; do
+   bash "$d/poc.sh"; echo "$d -> $?"; done` — all **non-zero**.
+
+## Documentation — I am auditing this myself, so get it right
+
+`docs/SHARED_LIBRARIES_DESIGN.md` currently states the vocabulary as
+`number`, `text`, `boolean`, `file`, `value` without distinguishing parameter
+from return position — which is how I got this wrong in the first place.
+Update it to state the rule precisely, per position, after your change.
+I will check it against the code myself and send back anything that does not
+match.
+
+## Known adjacent gap — do NOT fix here
+
+A `.lib`'s declared types are trusted, never verified against the `.so`
+(plan 294 findings 19/20 — a library declaring a return type its
+implementation does not provide crashes the consumer). This plan **widens**
+what a `.lib` may declare, so it widens that hole. Note it in the plan doc as
+a consequence; do not attempt to fix verification here.
+
+## Hard constraints
+
+- **Never `git add -A`.** Compiled Vox programs land in the CWD. Named paths
+  only; build test programs in a temp dir.
+- **Never `--no-gpg-sign`.** Hardware key; a hanging commit is waiting for a
+  human.
+- **No `Co-Authored-By:` trailers.**
+- **Do not spawn workers.** You are the worker.
+- Commit incrementally — one commit per half — so I can review as you go.
+
+## Reporting
+
+Report each half: done / not done, with the reason. Say plainly if this brief
+is wrong about the code — I would rather fix the brief than have you build on
+a false premise. Report what you could not do rather than silently reducing
+scope.

--- a/src/codegen/mod.rs
+++ b/src/codegen/mod.rs
@@ -88,6 +88,13 @@ pub struct CodeGenerator {
     // SysV stream; a scalar parameter occupies one. Both caller and callee
     // derive the word layout from this same vector so they agree.
     function_param_types: std::collections::HashMap<String, Vec<Type>>,
+    // The full declared return `Type` of each user/imported function, keyed
+    // the same way as `function_return_types` (which only keeps the coarse
+    // `VarType`). Needed so a `VarDecl` initialized from a call to a `.lib`
+    // function returning `list of <type>` can recover the element type and
+    // seed `list_element_types` for the declared variable (plan 296 -
+    // element typing crossing the `.lib` boundary in return position).
+    function_return_full_types: std::collections::HashMap<String, Type>,
     // Return type of the function currently being codegen'd (None at top
     // level). When it is `Type::Value`, the `Return` path must leave the
     // value's runtime tag in r11 for the caller to consume.
@@ -254,38 +261,275 @@ pub struct LibBlock {
     pub funcs: Vec<LibFunction>,
 }
 
-/// Author-facing noun for a parameter type, matching the Vox source vocabulary
-/// the parser accepts in `with a <type> called <name>` (`number`, `text`,
-/// `boolean`, `file`, `buffer`, `list`, `map`, `value`). Returns `None` for
-/// `Unknown` (an untyped `with n` parameter) and types the parser never produces
-/// in a parameter position (`Float`/`decimal`, `Time`, `Timer`, `Void`).
-fn param_type_noun(t: &Type) -> Option<&'static str> {
+/// Author-facing noun for a scalar (non-collection) type — shared by
+/// `type_noun` itself and its `List`-element rendering.
+fn scalar_type_noun(t: &Type) -> Option<&'static str> {
     match t {
         Type::Integer => Some("number"),
+        Type::Float => Some("float"),
         Type::String => Some("text"),
         Type::Boolean => Some("boolean"),
         Type::File => Some("file"),
         Type::Buffer => Some("buffer"),
-        Type::List(_) => Some("list"),
-        Type::Map(_) => Some("map"),
+        Type::Time => Some("time"),
+        Type::Timer => Some("timer"),
         Type::Value => Some("value"),
         _ => None,
     }
 }
 
-/// Author-facing noun for a return type, matching the vocabulary the parser
-/// accepts in `Return a <type>,` (`number`, `text`, `boolean`, `file`,
-/// `value`). Returns `None` for `Void` (no `, returning` clause — the function
-/// returns nothing) and types the return-annotation parser never produces
-/// (`Float`, `Buffer`, `List`, `Map`, `Time`, `Timer`).
-fn return_type_noun(t: &Type) -> Option<&'static str> {
+/// Author-facing noun for a `.lib` parameter or return type — the same
+/// 11-type vocabulary in both positions (plan 296; the vocabulary used to
+/// differ by position — five types in return, eight in parameter — mirroring
+/// a restriction Vox source's own `Return a <type>,` no longer has). Returns
+/// `None` for `Void` (no `, returning` clause: the function returns nothing)
+/// and `Unknown` (an untyped `with n` parameter has no noun to render;
+/// callers fall back to `number`, matching `emit_function_call`'s untyped-
+/// param word count). A `List` renders `list of <elem>` when its element
+/// type is known — inferred by `collect_function_signatures` from the
+/// exporting library's own source, never author-declared (plan 296) — or
+/// bare `list` otherwise, exactly as before.
+fn type_noun(t: &Type) -> Option<String> {
     match t {
-        Type::Integer => Some("number"),
-        Type::String => Some("text"),
-        Type::Boolean => Some("boolean"),
-        Type::File => Some("file"),
-        Type::Value => Some("value"),
+        Type::List(elem) => Some(match scalar_type_noun(elem) {
+            Some(en) => format!("list of {}", en),
+            None => "list".to_string(),
+        }),
+        Type::Map(_) => Some("map".to_string()),
+        _ => scalar_type_noun(t).map(|s| s.to_string()),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Stage A3: inferring a `.lib`-exported list's element type
+// ---------------------------------------------------------------------------
+//
+// Vox source has no typed-list declaration syntax (plan 296 confirmed this
+// by inspection: every `Token::List` match in the parser hard-codes
+// `Type::List(Box::new(Type::Unknown))`) — the language's own design
+// principle is that the author picks the data and the compiler picks the
+// representation, so element type is inferred from how a list is built
+// (first append/literal), never declared. These functions apply that same
+// "infer, don't declare" rule specifically to a `.lib`-exported function's
+// OWN list parameters and list return, so the `.lib` can record a real
+// element type without any new Vox source syntax: the library author writes
+// nothing new, and an ordinary (non-exported) function's lists are
+// completely unaffected (only `collect_function_signatures`'s `LibFunction`
+// construction calls these — never `function_param_types` /
+// `function_return_types`, which drive this compilation unit's own codegen).
+//
+// This is a narrow, single-pass, non-flow-sensitive scan — deliberately NOT
+// the existing fixed-point `prescan_mixed_lists` machinery, which already
+// walks every function body but never seeds a function's own parameters
+// into its environment (so `Append s to out` with `s` a text parameter is
+// invisible to it; a separate, out-of-scope bug, see plan 296). Reusing or
+// extending that whole-program pre-scan here would carry its blast radius
+// into a change meant to touch only `.lib` emission. Any expression this
+// scan can't classify (a call result, an element read, disagreement between
+// two sites) makes it give up and report `Unknown` — the safe fallback that
+// exactly matches today's behavior (no annotation), never a wrong guess.
+
+/// A scalar expression's `Type`, for the handful of shapes this scan
+/// understands: a literal, or a reference to a parameter whose own
+/// (non-collection) type is already known. Anything else — a function call,
+/// an element/property read, a local built from something this scan didn't
+/// already trace — is `None`, which the caller treats as "give up."
+fn scalar_expr_type(expr: &Expr, param_types: &HashMap<String, Type>) -> Option<Type> {
+    match expr {
+        Expr::StringLit(_) => Some(Type::String),
+        Expr::IntegerLit(_) => Some(Type::Integer),
+        Expr::FloatLit(_) => Some(Type::Float),
+        Expr::BoolLit(_) => Some(Type::Boolean),
+        Expr::Identifier(n) => param_types.get(n).and_then(|t| match t {
+            Type::Integer | Type::Float | Type::String | Type::Boolean | Type::File
+            | Type::Buffer | Type::Time | Type::Timer | Type::Value => Some(t.clone()),
+            _ => None,
+        }),
         _ => None,
+    }
+}
+
+/// Join one observed element type into the running verdict: the first
+/// observation wins, a disagreeing later one (or an unclassifiable
+/// observation, `None`) taints the whole scan to `Unknown` via `conflict`.
+fn note_element_type(found: &mut Option<Type>, conflict: &mut bool, observed: Option<Type>) {
+    match observed {
+        None => *conflict = true,
+        Some(t) => match found {
+            Some(prev) if *prev != t => *conflict = true,
+            Some(_) => {}
+            None => *found = Some(t),
+        },
+    }
+}
+
+/// Recurse into a statement list's control-flow bodies the same shape
+/// `prescan_walk` does, collecting every `Append <expr> to target` and every
+/// `a list called target is [...]` literal that names `target`.
+fn scan_list_element_type(
+    target: &str,
+    param_types: &HashMap<String, Type>,
+    body: &[Statement],
+    found: &mut Option<Type>,
+    conflict: &mut bool,
+) {
+    for stmt in body {
+        match stmt {
+            Statement::ListAppend { list, value } if list == target => {
+                note_element_type(found, conflict, scalar_expr_type(value, param_types));
+            }
+            Statement::VarDecl {
+                name,
+                value: Some(Expr::ListLit { elements }),
+                ..
+            } if name == target => {
+                for e in elements {
+                    note_element_type(found, conflict, scalar_expr_type(e, param_types));
+                }
+            }
+            Statement::If {
+                then_block,
+                else_if_blocks,
+                else_block,
+                ..
+            } => {
+                scan_list_element_type(target, param_types, then_block, found, conflict);
+                for (_, blk) in else_if_blocks {
+                    scan_list_element_type(target, param_types, blk, found, conflict);
+                }
+                if let Some(blk) = else_block {
+                    scan_list_element_type(target, param_types, blk, found, conflict);
+                }
+            }
+            Statement::While { body, .. }
+            | Statement::ForRange { body, .. }
+            | Statement::ForEach { body, .. }
+            | Statement::Repeat { body, .. } => {
+                scan_list_element_type(target, param_types, body, found, conflict);
+            }
+            Statement::OnError { actions } => {
+                scan_list_element_type(target, param_types, actions, found, conflict);
+            }
+            _ => {}
+        }
+    }
+}
+
+/// Infer a homogeneous element type for the list built through `target`
+/// (a parameter name, most often — the plan's own verified repro appends a
+/// parameter: `Append s to out.`) within one function's body. `Unknown`
+/// when the scan finds disagreement or nothing at all.
+fn infer_list_element_type(
+    target: &str,
+    param_types: &HashMap<String, Type>,
+    body: &[Statement],
+) -> Type {
+    let mut found: Option<Type> = None;
+    let mut conflict = false;
+    scan_list_element_type(target, param_types, body, &mut found, &mut conflict);
+    if conflict {
+        Type::Unknown
+    } else {
+        found.unwrap_or(Type::Unknown)
+    }
+}
+
+/// Collect every `Return <expr>.`'s value expression, recursing into
+/// control-flow bodies the same way `scan_list_element_type` does — a
+/// function may return from more than one branch.
+fn scan_return_values<'a>(body: &'a [Statement], out: &mut Vec<&'a Expr>) {
+    for stmt in body {
+        match stmt {
+            Statement::Return { value: Some(v), .. } => out.push(v),
+            Statement::If {
+                then_block,
+                else_if_blocks,
+                else_block,
+                ..
+            } => {
+                scan_return_values(then_block, out);
+                for (_, blk) in else_if_blocks {
+                    scan_return_values(blk, out);
+                }
+                if let Some(blk) = else_block {
+                    scan_return_values(blk, out);
+                }
+            }
+            Statement::While { body, .. }
+            | Statement::ForRange { body, .. }
+            | Statement::ForEach { body, .. }
+            | Statement::Repeat { body, .. } => {
+                scan_return_values(body, out);
+            }
+            Statement::OnError { actions } => {
+                scan_return_values(actions, out);
+            }
+            _ => {}
+        }
+    }
+}
+
+/// Infer a homogeneous element type for a function's returned list: every
+/// `Return <list-literal>.` classifies its elements directly; every
+/// `Return <identifier>.` re-runs the parameter/append scan for that name
+/// (covering both `Return out.` for an appended-to parameter and a plain
+/// local list built and returned in the same function, as in the plan's own
+/// bare-return baseline). Anything else (a call result, disagreement across
+/// several `Return`s) gives up, same as `infer_list_element_type`.
+fn infer_return_list_element_type(param_types: &HashMap<String, Type>, body: &[Statement]) -> Type {
+    let mut returns = Vec::new();
+    scan_return_values(body, &mut returns);
+    let mut found: Option<Type> = None;
+    let mut conflict = false;
+    for expr in returns {
+        match expr {
+            Expr::ListLit { elements } => {
+                for e in elements {
+                    note_element_type(&mut found, &mut conflict, scalar_expr_type(e, param_types));
+                }
+            }
+            Expr::Identifier(name) => {
+                let mut sub_found: Option<Type> = None;
+                let mut sub_conflict = false;
+                scan_list_element_type(name, param_types, body, &mut sub_found, &mut sub_conflict);
+                if sub_conflict {
+                    conflict = true;
+                } else {
+                    note_element_type(&mut found, &mut conflict, sub_found);
+                }
+            }
+            _ => conflict = true,
+        }
+    }
+    if conflict {
+        Type::Unknown
+    } else {
+        found.unwrap_or(Type::Unknown)
+    }
+}
+
+/// Map a `.lib`-declared list element `Type` to the `VarType` a for-each
+/// loop variable / print site should use — mirrors the scalar mapping used
+/// for a declared local's own `VarType` elsewhere in this module (`VarDecl`,
+/// function parameters). `Value` maps to `Mixed`: a `list of value`
+/// element genuinely carries its own runtime tag, so this routes it through
+/// the SAME per-iteration tag-dispatch a heterogeneous list already uses.
+/// `File`/`Time`/`Timer` fall through to `Unknown`, which already prints an
+/// opaque handle as a plain integer — correct for all three. `list of
+/// <type>` only ever names one of these nine scalar nouns (`take_list_type`
+/// on the `.lib` side), so `List`/`Map` never reach here in practice.
+fn list_element_vartype(t: &Type) -> VarType {
+    match t {
+        Type::Integer => VarType::Integer,
+        Type::Float => VarType::Float,
+        Type::String => VarType::String,
+        Type::Boolean => VarType::Boolean,
+        // Buffer content is a NUL-terminated pointer, printed exactly like
+        // text (`type_to_tag`'s existing `VarType::String | VarType::Buffer
+        // => TAG_STRING` rule).
+        Type::Buffer => VarType::String,
+        Type::Value => VarType::Mixed,
+        _ => VarType::Unknown,
     }
 }
 
@@ -345,14 +589,14 @@ pub fn render_lib_file(blocks: &[LibBlock], so_filename: &str) -> String {
                         // `emit_function_call`'s `word_count`). Library authors
                         // should type their exports; see the A3 report for the
                         // caveat.
-                        let noun = param_type_noun(ptype).unwrap_or("number");
+                        let noun = type_noun(ptype).unwrap_or_else(|| "number".to_string());
                         format!("a {} called {}", noun, format_lib_name(pname))
                     })
                     .collect::<Vec<_>>()
                     .join(" and ");
                 out.push_str(&joined);
             }
-            if let Some(rnoun) = return_type_noun(&func.return_type) {
+            if let Some(rnoun) = type_noun(&func.return_type) {
                 out.push_str(&format!(", returning a {}", rnoun));
             }
             out.push_str(".\n");
@@ -504,6 +748,7 @@ impl CodeGenerator {
             uses_strings: false,
             function_return_types: std::collections::HashMap::new(),
             function_param_types: std::collections::HashMap::new(),
+            function_return_full_types: std::collections::HashMap::new(),
             current_function_return_type: None,
             loop_stack: Vec::new(),
             flag_schemas: Vec::new(),
@@ -943,6 +1188,25 @@ impl CodeGenerator {
         // the `call` below emits.
         let label = self.resolved_call_label(name);
         let param_types = self.function_param_types.get(&label).cloned().unwrap_or_default();
+        // Plan 296: a `.lib` parameter declared `list of <type>` carries a
+        // real element type (`Type::List(Box<non-Unknown>)`) rather than the
+        // usual `Unknown`. When the argument is a plain local variable,
+        // record that element type for it here — the same table
+        // (`list_element_types`) a local `Append <literal> to x` already
+        // populates, so every later read of that variable (a `for each`
+        // print, in particular) sees a real type instead of defaulting to
+        // "don't know." This is additive only: it fires exclusively for a
+        // `.lib` import whose ToC entry spelled `list of <type>`; a bare
+        // `list` parameter (every `.lib` ever emitted before this plan)
+        // still resolves to `Type::List(Unknown)` here and changes nothing.
+        for (i, arg) in args.iter().enumerate() {
+            if let (Some(Type::List(inner)), Expr::Identifier(argname)) = (param_types.get(i), arg) {
+                if !matches!(**inner, Type::Unknown) {
+                    self.list_element_types
+                        .insert(argname.clone(), list_element_vartype(inner));
+                }
+            }
+        }
         let is_value_param = |i: usize| -> bool {
             param_types.get(i) == Some(&Type::Value)
         };
@@ -1185,6 +1449,7 @@ impl CodeGenerator {
     fn collect_function_signatures(&mut self, program: &Program) {
         self.function_return_types.clear();
         self.function_param_types.clear();
+        self.function_return_full_types.clear();
         // Track the library identity as we walk so each function is keyed by
         // its OWN `<lib>_<ver>_<func>` label, not the authored name. This is
         // what scopes the signature tables: two libraries in one .so each
@@ -1208,7 +1473,7 @@ impl CodeGenerator {
                 Statement::LibraryDecl { name, version } => {
                     current_lib = Some((name.clone(), version.clone()));
                 }
-                Statement::FunctionDef { name, params, return_type, .. } => {
+                Statement::FunctionDef { name, params, return_type, body, .. } => {
                     let key = make_function_label(
                         self.shared_lib_mode,
                         current_lib.as_ref(),
@@ -1228,6 +1493,7 @@ impl CodeGenerator {
                         _ => VarType::Unknown,
                     };
                     self.function_return_types.insert(key.clone(), vt);
+                    self.function_return_full_types.insert(key.clone(), return_type.clone());
                     self.function_param_types
                         .insert(key, params.iter().map(|(_, t)| t.clone()).collect());
 
@@ -1247,10 +1513,38 @@ impl CodeGenerator {
                                     i
                                 }
                             };
+                            // The `.lib` records a real list element type when
+                            // one can be inferred from this function's OWN
+                            // body (plan 296) — the exported interface only;
+                            // `function_param_types`/`function_return_types`
+                            // above (this compilation unit's own codegen)
+                            // keep the plain declared type unchanged.
+                            let param_env: HashMap<String, Type> =
+                                params.iter().cloned().collect();
+                            let lib_params: Vec<(String, Type)> = params
+                                .iter()
+                                .map(|(pname, ptype)| match ptype {
+                                    Type::List(inner) if matches!(**inner, Type::Unknown) => (
+                                        pname.clone(),
+                                        Type::List(Box::new(infer_list_element_type(
+                                            pname, &param_env, body,
+                                        ))),
+                                    ),
+                                    _ => (pname.clone(), ptype.clone()),
+                                })
+                                .collect();
+                            let lib_return_type = match return_type {
+                                Type::List(inner) if matches!(**inner, Type::Unknown) => {
+                                    Type::List(Box::new(infer_return_list_element_type(
+                                        &param_env, body,
+                                    )))
+                                }
+                                other => other.clone(),
+                            };
                             lib_blocks[idx].funcs.push(LibFunction {
                                 name: name.clone(),
-                                params: params.clone(),
-                                return_type: return_type.clone(),
+                                params: lib_params,
+                                return_type: lib_return_type,
                             });
                         }
                     }
@@ -1278,6 +1572,8 @@ impl CodeGenerator {
                 _ => VarType::Unknown,
             };
             self.function_return_types.insert(imp.mangled.clone(), vt);
+            self.function_return_full_types
+                .insert(imp.mangled.clone(), imp.return_type.clone());
             self.function_param_types.insert(
                 imp.mangled.clone(),
                 imp.params.iter().map(|(_, t)| t.clone()).collect(),
@@ -2764,6 +3060,23 @@ impl CodeGenerator {
                         Expr::EnvironmentVariableFirst | Expr::EnvironmentVariableLast
                     ) {
                         self.variable_types.insert(name.clone(), VarType::String);
+                    }
+                    // A call to a `.lib` function declared `returning a
+                    // list of <type>` carries a real element type (plan
+                    // 296) — the symmetric case to `emit_function_call`'s
+                    // parameter-side propagation above. A call to anything
+                    // else (a local function, an unannotated `.lib`
+                    // return, a runtime helper) resolves to
+                    // `Type::List(Unknown)` here, so this is a no-op for
+                    // it, exactly today's behavior.
+                    else if let Expr::FunctionCall { name: fname, .. } = val {
+                        let label = self.resolved_call_label(fname);
+                        if let Some(Type::List(inner)) = self.function_return_full_types.get(&label) {
+                            if !matches!(**inner, Type::Unknown) {
+                                self.list_element_types
+                                    .insert(name.clone(), list_element_vartype(inner));
+                            }
+                        }
                     }
                     // Initializing from another variable: inherit its type
                     // (and element type, for lists) unless the declaration
@@ -7440,6 +7753,7 @@ mod tests {
     //! so a regression in `generate_print` is caught without assembling.
     use crate::analyzer::Analyzer;
     use crate::lexer::Lexer;
+    use crate::parser::ast::Type;
     use crate::parser::Parser;
     use super::{CodeGenerator, LibBlock};
 
@@ -8963,5 +9277,166 @@ To run.\n  Print double of 21.\n";
         );
         let quoted = parse_snippet("a number called 'nothing' is 1.");
         assert!(quoted.is_ok(), "quoted 'nothing' is a legal non-canonical name; only the bare form is reserved");
+    }
+
+    // -----------------------------------------------------------------
+    // Plan 296 — full type-vocabulary parity, both `.lib` positions
+    // -----------------------------------------------------------------
+    //
+    // Regression matrix: every one of the 11 expressible types (`Type::Void`
+    // and `Type::Unknown` excluded by design — see
+    // docs/plans/296_lib_collection_types.md) must parse and emit
+    // identically as a `.lib` PARAMETER and a RETURN type. Each case goes
+    // through the real pipeline — source -> `collect_function_signatures`
+    // -> `render_lib_file` -> `parse_lib_text` — so a vocabulary drift
+    // between the emitter (`type_noun`) and the parser (`take_type`) fails
+    // here, not just a spot check of one side.
+    #[test]
+    fn plan_296_full_type_vocabulary_round_trips_both_positions() {
+        let cases: &[(&str, Type)] = &[
+            ("number", Type::Integer),
+            ("float", Type::Float),
+            ("text", Type::String),
+            ("boolean", Type::Boolean),
+            ("list", Type::List(Box::new(Type::Unknown))),
+            ("map", Type::Map(Box::new(Type::Unknown))),
+            ("buffer", Type::Buffer),
+            ("file", Type::File),
+            ("time", Type::Time),
+            ("timer", Type::Timer),
+            ("value", Type::Value),
+        ];
+        for (noun, expected) in cases {
+            let src = format!(
+                "Library matrix version \"1.0\".\nTo f with a {} called x.\n  Return a {}, x.\n",
+                noun, noun
+            );
+            let (blocks, _exports) = compile_shared_with_libs(&src);
+            assert_eq!(blocks.len(), 1, "case {}: one Library block", noun);
+            assert_eq!(blocks[0].funcs.len(), 1, "case {}: one function", noun);
+            let f = &blocks[0].funcs[0];
+            assert_eq!(f.params[0].1, *expected, "case {}: emitted parameter type", noun);
+            assert_eq!(f.return_type, *expected, "case {}: emitted return type", noun);
+
+            let emitted = super::render_lib_file(&blocks, "libmatrix.so");
+            let reparsed = crate::lib_file::parse_lib_text(&emitted).unwrap_or_else(|e| {
+                panic!("case {}: emitted .lib failed to reparse: {}\n{}", noun, e, emitted)
+            });
+            let rf = &reparsed[0].funcs[0];
+            assert_eq!(rf.params[0].1, *expected, "case {}: round-tripped parameter type; emitted:\n{}", noun, emitted);
+            assert_eq!(rf.return_type, *expected, "case {}: round-tripped return type; emitted:\n{}", noun, emitted);
+        }
+    }
+
+    // List element typing (plan 296, "Element typing crosses the .lib
+    // boundary"): every scalar noun `take_list_type` accepts as a list
+    // element must be correctly INFERRED from a single `Append <expr> to
+    // <param>` site where `<expr>` references a same-named-type parameter
+    // (the plan's own verified repro appends a parameter: `Append s to
+    // out.`), emitted as `list of <noun>`, and round-trip back through the
+    // parser to the same `Type`.
+    #[test]
+    fn plan_296_list_element_type_matrix_parameter() {
+        let cases: &[(&str, Type)] = &[
+            ("number", Type::Integer),
+            ("float", Type::Float),
+            ("text", Type::String),
+            ("boolean", Type::Boolean),
+            ("file", Type::File),
+            ("buffer", Type::Buffer),
+            ("time", Type::Time),
+            ("timer", Type::Timer),
+            ("value", Type::Value),
+        ];
+        for (noun, expected) in cases {
+            let src = format!(
+                "Library elemkit version \"1.0\".\nTo f with a {} called s and a list called out.\n  Append s to out.\n",
+                noun
+            );
+            let (blocks, _exports) = compile_shared_with_libs(&src);
+            let f = &blocks[0].funcs[0];
+            let want = Type::List(Box::new(expected.clone()));
+            assert_eq!(
+                f.params[1].1, want,
+                "case {}: inferred parameter element type; got params {:?}", noun, f.params
+            );
+
+            let emitted = super::render_lib_file(&blocks, "libelem.so");
+            assert!(
+                emitted.contains(&format!("a list of {} called out", noun)),
+                "case {}: emitted .lib must render 'list of {}'; got:\n{}", noun, noun, emitted
+            );
+            let reparsed = crate::lib_file::parse_lib_text(&emitted).expect("reparse emitted .lib");
+            assert_eq!(
+                reparsed[0].funcs[0].params[1].1, want,
+                "case {}: round-tripped parameter element type", noun
+            );
+        }
+    }
+
+    // Same matrix for a RETURNED list: the element type is inferred from a
+    // local list variable built with `Append` inside the function and
+    // returned with a declared `Return a list, <name>.` (bare, undeclared
+    // `Return <name>.` records no return type at all — see
+    // `lib_file_return_after_other_statement_carries_return_type` and
+    // LANGUAGE.md's ".lib" section: an entry with no `returning` clause
+    // means the function returns nothing, so a declared return type is the
+    // precondition for the `.lib` to say anything about the return at all).
+    #[test]
+    fn plan_296_list_element_type_matrix_return() {
+        let cases: &[(&str, Type)] = &[
+            ("number", Type::Integer),
+            ("float", Type::Float),
+            ("text", Type::String),
+            ("boolean", Type::Boolean),
+            ("file", Type::File),
+            ("buffer", Type::Buffer),
+            ("time", Type::Time),
+            ("timer", Type::Timer),
+            ("value", Type::Value),
+        ];
+        for (noun, expected) in cases {
+            let src = format!(
+                "Library elemretkit version \"1.0\".\nTo f with a {} called s.\n  a list called out is [].\n  Append s to out.\n  Return a list, out.\n",
+                noun
+            );
+            let (blocks, _exports) = compile_shared_with_libs(&src);
+            let f = &blocks[0].funcs[0];
+            let want = Type::List(Box::new(expected.clone()));
+            assert_eq!(
+                f.return_type, want,
+                "case {}: inferred return element type; got {:?}", noun, f.return_type
+            );
+
+            let emitted = super::render_lib_file(&blocks, "libelemret.so");
+            assert!(
+                emitted.contains(&format!(", returning a list of {}", noun)),
+                "case {}: emitted .lib must render 'returning a list of {}'; got:\n{}", noun, noun, emitted
+            );
+            let reparsed = crate::lib_file::parse_lib_text(&emitted).expect("reparse emitted .lib");
+            assert_eq!(
+                reparsed[0].funcs[0].return_type, want,
+                "case {}: round-tripped return element type", noun
+            );
+        }
+    }
+
+    // A list that disagrees on element type (or has none at all) must stay
+    // untyped, exactly as before this plan — a wrong guess would be worse
+    // than no annotation.
+    #[test]
+    fn plan_296_list_element_type_stays_unknown_on_disagreement_or_no_evidence() {
+        let disagreeing = "\
+Library mixedkit version \"1.0\".\n\
+To f with a text called s and a number called n and a list called out.\n  \
+Append s to out.\n  Append n to out.\n";
+        let (blocks, _) = compile_shared_with_libs(disagreeing);
+        assert_eq!(blocks[0].funcs[0].params[2].1, Type::List(Box::new(Type::Unknown)));
+
+        let no_evidence = "\
+Library emptykit version \"1.0\".\n\
+To f with a list called out.\n  Print \"noop\".\n";
+        let (blocks, _) = compile_shared_with_libs(no_evidence);
+        assert_eq!(blocks[0].funcs[0].params[0].1, Type::List(Box::new(Type::Unknown)));
     }
 }

--- a/src/codegen/mod.rs
+++ b/src/codegen/mod.rs
@@ -1363,6 +1363,32 @@ impl CodeGenerator {
         }
     }
 
+    /// The resolved call-target label for `val`, if it is a function call —
+    /// either the unambiguous `Expr::FunctionCall` shape (an explicit
+    /// `of`/`with`/`to` argument list), or a bare/quoted identifier in
+    /// expression position that names a zero-argument function rather than
+    /// a variable. The second shape is the one plan 296's first cut of
+    /// list-return element typing missed: `a list called got is 'tokens'.`
+    /// has no connector, so the parser can't tell it's a call — it produces
+    /// `Expr::Identifier("tokens")`, indistinguishable at the AST level
+    /// from a variable reference. `generate_expr`'s own Identifier arm
+    /// resolves the exact same ambiguity (plan 270 G4: try a variable load
+    /// first, fall back to `zero_arg_func_return_type`); this mirrors that
+    /// resolution order so a variable always wins over a same-named
+    /// zero-arg function, here too.
+    fn call_label_for_list_return(&self, val: &Expr) -> Option<String> {
+        match val {
+            Expr::FunctionCall { name, .. } => Some(self.resolved_call_label(name)),
+            Expr::Identifier(name)
+                if self.get_var(name).is_none() && self.global_var_label(name).is_none() =>
+            {
+                self.zero_arg_func_return_type(name)
+                    .map(|_| self.resolved_call_label(name))
+            }
+            _ => None,
+        }
+    }
+
     /// The mangled labels of functions exported by a `--shared` compile, in
     /// emission order. Populated during `generate`; the linker's version
     /// script names exactly these as the library's public symbols.
@@ -3064,13 +3090,15 @@ impl CodeGenerator {
                     // A call to a `.lib` function declared `returning a
                     // list of <type>` carries a real element type (plan
                     // 296) — the symmetric case to `emit_function_call`'s
-                    // parameter-side propagation above. A call to anything
-                    // else (a local function, an unannotated `.lib`
-                    // return, a runtime helper) resolves to
-                    // `Type::List(Unknown)` here, so this is a no-op for
+                    // parameter-side propagation above. Covers BOTH call
+                    // shapes: an explicit `of`/`with` argument list
+                    // (`Expr::FunctionCall`) and a bare zero-argument call
+                    // (`Expr::Identifier`, see `call_label_for_list_return`).
+                    // A call to anything else (a local function, an
+                    // unannotated `.lib` return, a runtime helper) resolves
+                    // to `Type::List(Unknown)` here, so this is a no-op for
                     // it, exactly today's behavior.
-                    else if let Expr::FunctionCall { name: fname, .. } = val {
-                        let label = self.resolved_call_label(fname);
+                    else if let Some(label) = self.call_label_for_list_return(val) {
                         if let Some(Type::List(inner)) = self.function_return_full_types.get(&label) {
                             if !matches!(**inner, Type::Unknown) {
                                 self.list_element_types

--- a/src/lib_file.rs
+++ b/src/lib_file.rs
@@ -182,23 +182,28 @@ impl LibParser {
         }
     }
 
-    /// The signature type vocabulary. Parameter positions additionally accept
-    /// the composite/collection nouns the A3 emitter can write (`buffer`,
-    /// `list`, `map`) so the file the compiler emits always re-parses —
-    /// parameter types are trusted straight from the file either way.
-    /// Return positions accept exactly the normative five (`number`, `text`,
-    /// `boolean`, `file`, `value`); anything else is an error naming the
-    /// unsupported type.
+    /// The signature type vocabulary: the full 11 expressible `Type`
+    /// variants (number, float, text, boolean, list, map, buffer, file,
+    /// time, timer, value), identical in parameter and return position
+    /// (plan 296 — the old split, five types in return position and eight
+    /// in parameter position, mirrored a restriction Vox source's own
+    /// `Return a <type>,` no longer has). `position` still names the spot
+    /// for diagnostics; it no longer gates which tokens are accepted.
     fn take_type(&mut self, position: &'static str) -> Result<Type, String> {
+        if *self.current() == Token::List {
+            return self.take_list_type();
+        }
         let ty = match self.current() {
             Token::Number => Some(Type::Integer),
+            Token::Float => Some(Type::Float),
             Token::Text => Some(Type::String),
             Token::Boolean => Some(Type::Boolean),
             Token::File => Some(Type::File),
+            Token::Buffer => Some(Type::Buffer),
+            Token::Map => Some(Type::Map(Box::new(Type::Unknown))),
+            Token::Time => Some(Type::Time),
+            Token::Timer => Some(Type::Timer),
             Token::Identifier(n) if n.eq_ignore_ascii_case("value") => Some(Type::Value),
-            Token::Buffer if position == "parameter" => Some(Type::Buffer),
-            Token::List if position == "parameter" => Some(Type::List(Box::new(Type::Unknown))),
-            Token::Map if position == "parameter" => Some(Type::Map(Box::new(Type::Unknown))),
             _ => None,
         };
         match ty {
@@ -209,23 +214,58 @@ impl LibParser {
             None => {
                 let found = match self.current() {
                     Token::Identifier(n) => format!("'{}'", n),
-                    Token::Buffer => "'buffer'".to_string(),
-                    Token::List => "'list'".to_string(),
-                    Token::Map => "'map'".to_string(),
                     other => format!("{:?}", other),
-                };
-                let allowed = if position == "return" {
-                    "number, text, boolean, file, value"
-                } else {
-                    "number, text, boolean, file, buffer, list, map, value"
                 };
                 Err(self.err(format!(
                     "unsupported type {} in a {} position — a .lib states types \
-                     as one of: {}",
-                    found, position, allowed
+                     as one of: number, float, text, boolean, list, map, buffer, \
+                     file, time, timer, value",
+                    found, position
                 )))
             }
         }
+    }
+
+    /// A `.lib` list type: bare `list` (element type `Unknown`, exactly as
+    /// before — backward compatible with every `.lib` ever emitted) or
+    /// `list of <noun>`, where `<noun>` is any non-collection type (no
+    /// nested list-of-list/map: out of scope, no evidence requires it).
+    /// `list of <noun>` exists only in this grammar — it is how the A3
+    /// emitter serializes an element type it *infers* from the exporting
+    /// library's own source (plan 296), never syntax a `.lib` author
+    /// writes expecting Vox source to match it: Vox source has no
+    /// generic/typed-collection declaration syntax at all.
+    fn take_list_type(&mut self) -> Result<Type, String> {
+        self.advance(); // consume 'list'
+        if *self.current() != Token::Of {
+            return Ok(Type::List(Box::new(Type::Unknown)));
+        }
+        self.advance(); // consume 'of'
+        let elem = match self.current() {
+            Token::Number => Type::Integer,
+            Token::Float => Type::Float,
+            Token::Text => Type::String,
+            Token::Boolean => Type::Boolean,
+            Token::File => Type::File,
+            Token::Buffer => Type::Buffer,
+            Token::Time => Type::Time,
+            Token::Timer => Type::Timer,
+            Token::Identifier(n) if n.eq_ignore_ascii_case("value") => Type::Value,
+            other => {
+                let found = match other {
+                    Token::Identifier(n) => format!("'{}'", n),
+                    o => format!("{:?}", o),
+                };
+                return Err(self.err(format!(
+                    "unsupported list element type {} — 'list of' takes one of: \
+                     number, float, text, boolean, buffer, file, time, timer, \
+                     value (no nested list or map)",
+                    found
+                )));
+            }
+        };
+        self.advance();
+        Ok(Type::List(Box::new(elem)))
     }
 
     /// One table-of-contents entry, which is exactly one physical line:
@@ -793,14 +833,43 @@ Table of Contents:\n\
 
     #[test]
     fn unsupported_return_type_is_named() {
+        // `buffer` used to be the pinned example here, back when return
+        // position accepted only five types. Plan 296 widened return
+        // position to the full 11-type vocabulary (buffer included), so
+        // this now exercises the diagnostic with a genuinely nonexistent
+        // type instead — the "named unsupported type" coverage this test
+        // exists for is not about buffer specifically, it's about the
+        // parser naming whatever it rejects.
         let text = "Library n version \"1.0\".\n\
 Location \"./n.so\".\n\
 \n\
 Table of Contents:\n\
-    To f, returning a buffer.\n";
+    To f, returning a widget.\n";
         let err = parse_lib_text(text).unwrap_err();
         assert!(err.contains("unsupported type"), "got: {}", err);
-        assert!(err.contains("'buffer'"), "got: {}", err);
+        assert!(err.contains("'widget'"), "got: {}", err);
+    }
+
+    #[test]
+    fn void_and_unknown_have_no_surface_spelling_in_return_position() {
+        // Plan 296's judgment call: `Void` is spelled by omitting the
+        // `returning` clause entirely (never `returning a void`), and
+        // `Unknown` is an internal placeholder with no author-facing
+        // spelling at all. Both must still be rejected by name, the same
+        // as any other nonexistent type noun.
+        for word in ["void", "unknown"] {
+            let text = format!(
+                "Library n version \"1.0\".\n\
+Location \"./n.so\".\n\
+\n\
+Table of Contents:\n\
+    To f, returning a {}.\n",
+                word
+            );
+            let err = parse_lib_text(&text).unwrap_err();
+            assert!(err.contains("unsupported type"), "got: {}", err);
+            assert!(err.contains(&format!("'{}'", word)), "got: {}", err);
+        }
     }
 
     #[test]

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -2150,7 +2150,38 @@ impl Parser {
         
         Ok(Statement::Repeat { count, body })
     }
-    
+
+    /// The 11-type declaration vocabulary shared by a function parameter
+    /// type (`with a <type> called x`) and a declared return type (`Return
+    /// a <type>,`, both the inline path in `parse_function_def` and the
+    /// Gate-B path here in `parse_return`). One table so these call sites
+    /// cannot drift into accepting different sets again — they had: Gate B
+    /// recognized only number/text/boolean while the inline return path
+    /// separately also took file/value, and the parameter path separately
+    /// took buffer/list/map but neither took float/time/timer. Does not
+    /// consume the token; callers advance after matching. `list`/`map`
+    /// declared this way stay element-untyped (`Unknown`) — Vox source has
+    /// no generic/typed-collection declaration syntax (plan 296).
+    fn declaration_type_token(&self) -> Option<Type> {
+        match self.current() {
+            Token::Number => Some(Type::Integer),
+            Token::Float => Some(Type::Float),
+            Token::Text => Some(Type::String),
+            Token::Boolean => Some(Type::Boolean),
+            Token::File => Some(Type::File),
+            Token::Buffer => Some(Type::Buffer),
+            Token::List => Some(Type::List(Box::new(Type::Unknown))),
+            Token::Map => Some(Type::Map(Box::new(Type::Unknown))),
+            Token::Time => Some(Type::Time),
+            Token::Timer => Some(Type::Timer),
+            // `value` is not a reserved keyword (it stays a usable
+            // identifier everywhere else); in a type position it denotes
+            // the dynamic `value` type.
+            Token::Identifier(n) if n == "value" => Some(Type::Value),
+            _ => None,
+        }
+    }
+
     fn parse_return(&mut self) -> Result<Statement, Box<CompileError>> {
         self.advance();
         self.skip_noise();
@@ -2164,13 +2195,7 @@ impl Parser {
                 self.skip_noise();
 
                 // Check if this is a type keyword followed by comma
-                if matches!(self.current(), Token::Number | Token::Text | Token::Boolean) {
-                    let declared_type = match self.current() {
-                        Token::Number => Type::Integer,
-                        Token::Text => Type::String,
-                        Token::Boolean => Type::Boolean,
-                        _ => unreachable!(),
-                    };
+                if let Some(declared_type) = self.declaration_type_token() {
                     self.advance();
                     self.skip_noise();
 
@@ -4236,19 +4261,9 @@ impl Parser {
                         self.skip_noise();
                     }
                     
-                    let param_type = match self.current() {
-                        Token::Number => { self.advance(); Type::Integer }
-                        Token::Text => { self.advance(); Type::String }
-                        Token::Boolean => { self.advance(); Type::Boolean }
-                        Token::File => { self.advance(); Type::File }
-                        Token::Buffer => { self.advance(); Type::Buffer }
-                        Token::List => { self.advance(); Type::List(Box::new(Type::Unknown)) }
-                        Token::Map => { self.advance(); Type::Map(Box::new(Type::Unknown)) }
-                        // `value` is not a reserved keyword (it stays a usable
-                        // identifier everywhere else); in a parameter type
-                        // position it denotes the dynamic `value` type.
-                        Token::Identifier(ref n) if n == "value" => { self.advance(); Type::Value }
-                        _ => Type::Unknown,
+                    let param_type = match self.declaration_type_token() {
+                        Some(t) => { self.advance(); t }
+                        None => Type::Unknown,
                     };
                     
                     self.skip_noise();
@@ -4295,17 +4310,9 @@ impl Parser {
             }
             
             let mut declared_type = None;
-            if matches!(self.current(), Token::Number | Token::Text | Token::Boolean | Token::File)
-                || matches!(self.current(), Token::Identifier(ref n) if n == "value")
-            {
-                return_type = match self.current() {
-                    Token::Number => { self.advance(); Type::Integer }
-                    Token::Text => { self.advance(); Type::String }
-                    Token::Boolean => { self.advance(); Type::Boolean }
-                    Token::File => { self.advance(); Type::File }
-                    Token::Identifier(ref n) if n == "value" => { self.advance(); Type::Value }
-                    _ => Type::Void,
-                };
+            if let Some(t) = self.declaration_type_token() {
+                self.advance();
+                return_type = t;
                 declared_type = Some(return_type.clone());
                 self.skip_noise();
                 self.expect(&Token::Comma);

--- a/tests/p296_full_type_vocabulary.rs
+++ b/tests/p296_full_type_vocabulary.rs
@@ -1,0 +1,131 @@
+// Plan 296 — regression matrix: every expressible Vox type (`Type::Void`
+// and `Type::Unknown` excluded by design — see
+// docs/plans/296_lib_collection_types.md) must work as an ordinary
+// function's PARAMETER type and its declared RETURN type, via both parsers
+// that accept `Return a <type>,`: the inline path in `parse_function_def`
+// (Return as the function's literal first statement) and Gate B's
+// `parse_return` (any later statement). The two used to disagree — Gate B
+// took only number/text/boolean while the inline path separately took
+// file/value and the parameter path separately took buffer/list/map — this
+// plan unified them onto one shared vocabulary table specifically so a
+// future narrowing of any one of the three fails a test here instead of
+// shipping silently.
+
+use std::fs;
+use std::process::{Command, Stdio};
+
+fn work_dir(tag: &str) -> std::path::PathBuf {
+    let work = std::env::temp_dir().join(format!("vox-p296-{}-{}", tag, std::process::id()));
+    let _ = fs::remove_dir_all(&work);
+    fs::create_dir_all(&work).expect("create temp work dir");
+    work
+}
+
+fn compile_ok(tag: &str, source: &str) {
+    let work = work_dir(tag);
+    fs::write(work.join("prog.vox"), source).expect("write prog.vox");
+    let vox = env!("CARGO_BIN_EXE_vox");
+    let bin = work.join("prog");
+    let output = Command::new(vox)
+        .arg(work.join("prog.vox"))
+        .arg("-o")
+        .arg(&bin)
+        .current_dir(&work)
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .output()
+        .expect("spawn vox");
+    assert!(
+        output.status.success(),
+        "case {}: compile should succeed; stderr:\n{}",
+        tag,
+        String::from_utf8_lossy(&output.stderr)
+    );
+    fs::remove_dir_all(&work).ok();
+}
+
+fn compile_err(tag: &str, source: &str) -> String {
+    let work = work_dir(tag);
+    fs::write(work.join("prog.vox"), source).expect("write prog.vox");
+    let vox = env!("CARGO_BIN_EXE_vox");
+    let bin = work.join("prog");
+    let output = Command::new(vox)
+        .arg(work.join("prog.vox"))
+        .arg("-o")
+        .arg(&bin)
+        .current_dir(&work)
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .output()
+        .expect("spawn vox");
+    assert!(
+        !output.status.success(),
+        "case {}: compile should fail, but it succeeded",
+        tag
+    );
+    fs::remove_dir_all(&work).ok();
+    String::from_utf8_lossy(&output.stderr).to_string()
+}
+
+const TYPES: &[&str] = &[
+    "number", "float", "text", "boolean", "list", "map", "buffer", "file", "time", "timer", "value",
+];
+
+#[test]
+fn return_inline_path_accepts_every_type() {
+    // Return as the function's literal first (and only) statement.
+    for ty in TYPES {
+        let src = format!("To 'give it'. Return a {}, 1.\n\nPrint \"ok\".\n", ty);
+        compile_ok(&format!("inline-{}", ty), &src);
+    }
+}
+
+#[test]
+fn return_gate_b_path_accepts_every_type() {
+    // A preceding statement forces Gate B (`parse_return`) instead of the
+    // inline first-statement path.
+    for ty in TYPES {
+        let src = format!(
+            "To 'give it'.\n  a number called x is 1.\n  Return a {}, x.\n\nPrint \"ok\".\n",
+            ty
+        );
+        compile_ok(&format!("gateb-{}", ty), &src);
+    }
+}
+
+#[test]
+fn parameter_type_accepts_every_type() {
+    for ty in TYPES {
+        let src = format!(
+            "To 'give it' with a {} called x. Return a number, 1.\n\nPrint \"ok\".\n",
+            ty
+        );
+        compile_ok(&format!("param-{}", ty), &src);
+    }
+}
+
+#[test]
+fn return_still_rejects_a_nonexistent_type_on_both_paths() {
+    // Void/Unknown stay unspellable (plan 296's judgment call), and a
+    // flatly bogus noun stays an error — widening the accepted vocabulary
+    // must not mean accepting anything.
+    let inline_err = compile_err(
+        "inline-bogus",
+        "To 'give it'. Return a bogus_type, 1.\n\nPrint \"ok\".\n",
+    );
+    assert!(
+        !inline_err.is_empty(),
+        "inline path: a nonexistent type must still produce a diagnostic"
+    );
+
+    let gateb_err = compile_err(
+        "gateb-bogus",
+        "To 'give it'.\n  a number called x is 1.\n  Return a bogus_type, x.\n\nPrint \"ok\".\n",
+    );
+    assert!(
+        !gateb_err.is_empty(),
+        "Gate B path: a nonexistent type must still produce a diagnostic"
+    );
+}

--- a/tests/p296_lib_element_type_runtime.rs
+++ b/tests/p296_lib_element_type_runtime.rs
@@ -1,0 +1,162 @@
+// Plan 296 — genuine end-to-end runtime verification for list element
+// typing across the `.lib` boundary.
+//
+// The codegen-level matrix tests (`plan_296_list_element_type_matrix_*` in
+// `src/codegen/mod.rs`) check the `.lib`'s declared/emitted TYPE and TEXT
+// only — they never compile a real consumer, link it, and run the binary.
+// That gap is exactly how the returned-list-LITERAL shape shipped broken:
+// the `.lib` correctly said `returning a list of text`, but the consumer
+// still printed raw pointers, because a bare zero-argument call in
+// expression position (`a list called got is 'tokens'.`, no `of`/`with`
+// connector) parses as `Expr::Identifier`, not `Expr::FunctionCall`, and
+// the first cut of the consumer-side element-type propagation only
+// recognized the latter shape. These tests compile a real library `.so` +
+// `.lib`, compile a SEPARATE consumer program against it, run the
+// resulting binary, and assert on real stdout — metadata assertions alone
+// already proved insufficient to catch this.
+
+use std::fs;
+use std::process::{Command, Stdio};
+
+fn work_dir(tag: &str) -> std::path::PathBuf {
+    let work = std::env::temp_dir().join(format!("vox-p296-rt-{}-{}", tag, std::process::id()));
+    let _ = fs::remove_dir_all(&work);
+    fs::create_dir_all(&work).expect("create temp work dir");
+    work
+}
+
+fn run(cmd: &mut Command) -> std::process::Output {
+    cmd.stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .output()
+        .expect("spawn process")
+}
+
+/// Build `lib_source` as a `--shared` library in `work`. The `.so`/`.lib`
+/// pair is always named `liblibrary.{so,lib}`; the `Library '<name>'
+/// version` INSIDE the source is what a `see` statement actually matches
+/// against, so callers are free to vary that per case.
+fn build_library(work: &std::path::Path, lib_source: &str) {
+    fs::write(work.join("lib.vox"), lib_source).expect("write lib.vox");
+    let vox = env!("CARGO_BIN_EXE_vox");
+    let output = run(Command::new(vox)
+        .arg(work.join("lib.vox"))
+        .arg("--shared")
+        .arg("-o")
+        .arg(work.join("liblibrary.so"))
+        .current_dir(work));
+    assert!(
+        output.status.success(),
+        "library build failed; stderr:\n{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        work.join("liblibrary.lib").exists(),
+        "expected liblibrary.lib to be emitted beside liblibrary.so"
+    );
+}
+
+/// Compile `consumer_source` (which `see`s the `.lib` built above) and run
+/// the resulting binary, returning its stdout.
+fn build_and_run_consumer(work: &std::path::Path, consumer_source: &str) -> String {
+    fs::write(work.join("consumer.vox"), consumer_source).expect("write consumer.vox");
+    let vox = env!("CARGO_BIN_EXE_vox");
+    let bin = work.join("consumer");
+    let output = run(Command::new(vox)
+        .arg(work.join("consumer.vox"))
+        .arg("-o")
+        .arg(&bin)
+        .current_dir(work));
+    assert!(
+        output.status.success(),
+        "consumer compile failed; stderr:\n{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let run_output = run(&mut Command::new(&bin));
+    assert!(
+        run_output.status.success(),
+        "consumer run failed; stderr:\n{}",
+        String::from_utf8_lossy(&run_output.stderr)
+    );
+    String::from_utf8_lossy(&run_output.stdout).to_string()
+}
+
+#[test]
+fn returned_list_built_via_append_prints_real_elements() {
+    // Case A from the owner's review: a library-local list is built with
+    // Append (a parameter forwarded in, plus a literal) and returned by
+    // name via an explicit `of` call. This shape already worked before
+    // this fix; pinned here so it can't silently regress.
+    let work = work_dir("append-return");
+    build_library(
+        &work,
+        "Library appendkit version \"1.0\".\n\n\
+         To 'collect it' with a text called s.\n  \
+         a list called out is [].\n  \
+         Append s to out.\n  \
+         Append \"extra\" to out.\n  \
+         Return a list, out.\n",
+    );
+    let stdout = build_and_run_consumer(
+        &work,
+        "see appendkit version \"1.0\" from \"./liblibrary.lib\".\n\n\
+         a list called got is 'collect it' of \"hello\".\n\
+         Print \"count={got's length}\".\n\
+         For each t from got, print \"got=[{t}]\".\n",
+    );
+    assert_eq!(stdout, "count=2\ngot=[hello]\ngot=[extra]\n");
+    fs::remove_dir_all(&work).ok();
+}
+
+#[test]
+fn returned_list_literal_via_zero_arg_call_prints_real_elements() {
+    // Case B from the owner's review — the shape that shipped broken. The
+    // returned list is a literal, and the consumer calls the zero-argument
+    // function with no `of`/`with` connector: `a list called got is
+    // 'tokens'.`. That parses as `Expr::Identifier`, not
+    // `Expr::FunctionCall` (plan 270 G4's zero-arg-call ambiguity), which
+    // the first cut of the return-side element-type propagation didn't
+    // account for.
+    let work = work_dir("literal-return");
+    build_library(
+        &work,
+        "Library litkit version \"1.0\".\n\n\
+         To tokens.\n  Return a list, [\"alpha\", \"beta\", \"gamma\"].\n",
+    );
+    let stdout = build_and_run_consumer(
+        &work,
+        "see litkit version \"1.0\" from \"./liblibrary.lib\".\n\n\
+         a list called got is 'tokens'.\n\
+         Print \"count={got's length}\".\n\
+         For each t from got, print \"got=[{t}]\".\n",
+    );
+    assert_eq!(stdout, "count=3\ngot=[alpha]\ngot=[beta]\ngot=[gamma]\n");
+    fs::remove_dir_all(&work).ok();
+}
+
+#[test]
+fn list_parameter_out_arg_prints_real_elements() {
+    // The plan's own verified repro (the parameter/out-arg shape), as a
+    // genuine runtime check alongside the two return-shape tests above —
+    // closing the same "metadata-only test gives false confidence" gap for
+    // every shape this plan touches, not just the one that broke.
+    let work = work_dir("param-outarg");
+    build_library(
+        &work,
+        "Library paramkit version \"1.0\".\n\n\
+         To 'split into' with a text called s and a list called out.\n  \
+         Append s to out.\n  \
+         Append \"second\" to out.\n",
+    );
+    let stdout = build_and_run_consumer(
+        &work,
+        "see paramkit version \"1.0\" from \"./liblibrary.lib\".\n\n\
+         a list called toks is [].\n\
+         'split into' with \"hello\" and toks.\n\
+         Print \"count={toks's length}\".\n\
+         For each t from toks, print \"tok=[{t}]\".\n",
+    );
+    assert_eq!(stdout, "count=2\ntok=[hello]\ntok=[second]\n");
+    fs::remove_dir_all(&work).ok();
+}


### PR DESCRIPTION
## The gap

A Vox function could only `Return` a handful of types — number, text, boolean, file, value — and the `.lib` interface format mirrored that same restriction, plus its own narrower one: `list`, `map`, and `buffer` were accepted as parameters but rejected as return types, and `float`/`time`/`timer` were missing from the vocabulary entirely, in both positions. None of this reflected a real limitation — the underlying calling convention already supported returning a list correctly for the simplest case; the type just couldn't be declared.

Three separate places in the parser independently decided their own version of "which types are allowed here," and had drifted out of sync with each other in the process — one accepted five types, another eight, a third only three.

## The fix

All 11 expressible Vox types now work identically as a parameter and as a declared return type, for ordinary functions and across the `.lib` boundary: `number, float, text, boolean, list, map, buffer, file, time, timer, value`. The three divergent parsers are unified onto one shared vocabulary table, so they cannot drift apart again.

`Void` (no `returning` clause) and `Unknown` (the parser's internal fallback for an undeclared type) deliberately get no new spelling — both already have a coherent, unambiguous meaning, and adding one would just be two ways to say the same thing.

## Element typing across the `.lib` boundary

A list returned or passed by a `.lib` function previously crossed with its element type erased, so a caller printed raw pointers instead of the actual values — even though the list's *length* and structure were always correct. The compiler now infers a list's element type from the exporting function's own body (no new declaration syntax — the author writes nothing extra) and carries it into the `.lib` file as `list of <type>`, for every call shape: an out-parameter, a list built incrementally and returned, and a list literal returned directly.

A map's value type is not inferred by this change — ``Map`` is never given a value type anywhere in the analyzer today, which is a separate, pre-existing gap.

## Verification

- `cargo test --release`: all suites green, including a genuine end-to-end runtime check — compiling a real `.so`+`.lib`, compiling a separate consumer against it, running the resulting binary, and asserting on actual stdout, for every returned-list call shape
- `./test.sh`: 219 passed, 0 failed, 6 skipped — exact baseline, unchanged
- Every file under `examples/` still compiles
- All 18 previously-catalogued memory-safety findings stay closed

## Known, documented, out of scope

- A `.lib`'s declared types are trusted, not verified against its `.so` — this change widens what a `.lib` may declare, which widens that existing gap. Tracked separately.
- Map value types remain unprovable at the boundary; a map read still cannot carry a real element type.