### PR TITLE
Bump version to 0.3.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,33 @@ All notable changes to Vox are documented here. The format is based on
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project
 adheres to [Semantic Versioning](https://semver.org/).
 
+## [0.3.4] - 2026-08-09
+
+### Fixed
+
+- **A `but if` branch on a non-`print` action (e.g. `append`) could silently
+  discard the rest of the program.** The branch's grammar didn't consume a
+  trailing `to <name>` clause, which desynced the parser into treating
+  everything after it as the body of a bogus, never-called function. This
+  was a regression: the previous release rejected the same source with a
+  compile error instead of silently discarding it. It's a compile error
+  again if the branch names the wrong target, and consumed correctly
+  otherwise.
+
+- **A function could only declare a handful of parameter and return types.**
+  `number`, `float`, `text`, `boolean`, `list`, `map`, `buffer`, `file`,
+  `time`, `timer`, and `value` now all work identically as a parameter type
+  and a declared return type, for ordinary functions and for shared-library
+  (`.lib`) functions alike. Previously only five of these were accepted as a
+  return type at all, and `float`/`time`/`timer` weren't accepted anywhere.
+
+- **A list returned or passed across a `.lib` boundary printed raw memory
+  addresses instead of its actual contents.** The list's length and
+  structure always crossed correctly; only its element type was lost. The
+  compiler now infers a list's element type from the exporting function's
+  own code and carries it across the boundary automatically, for every call
+  shape - no new syntax required.
+
 ## [0.3.3] - 2026-08-08
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -59,7 +59,7 @@ checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
 name = "vox"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "thiserror",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vox"
-version = "0.3.3"
+version = "0.3.4"
 edition = "2021"
 rust-version = "1.87"
 description = "A systems level compiler for Vox (sentence based code)"


### PR DESCRIPTION
Patch release covering two fixes already on `main` that shipped without a version bump:

- The `but if` append regression (#125)
- Full type-vocabulary parity for parameters, return types, and `.lib` list element typing (#126)

Both are additive/bug-fix in nature — no breaking changes, exact test baseline held (219/0/6).